### PR TITLE
devices: legacy: give the UART per-device metrics

### DIFF
--- a/src/vmm/src/device_manager/legacy.rs
+++ b/src/vmm/src/device_manager/legacy.rs
@@ -148,8 +148,10 @@ mod tests {
     use vm_superio::Serial;
     use vmm_sys_util::eventfd::EventFd;
 
+    use std::sync::Arc;
+
     use super::*;
-    use crate::devices::legacy::serial::{SerialOut, SerialOutInner};
+    use crate::devices::legacy::serial::{SerialDeviceMetrics, SerialOut, SerialOutInner};
     use crate::devices::legacy::{EventFdTrigger, SerialEventsWrapper};
     use crate::vstate::vm::tests::setup_vm_with_memory;
 
@@ -161,9 +163,7 @@ mod tests {
             stdio_serial: Arc::new(Mutex::new(SerialDevice {
                 serial: Serial::with_events(
                     EventFdTrigger::new(EventFd::new(EFD_NONBLOCK).unwrap()),
-                    SerialEventsWrapper {
-                        buffer_ready_event_fd: None,
-                    },
+                    SerialEventsWrapper::new(Arc::new(SerialDeviceMetrics::default()), None),
                     SerialOut::new(SerialOutInner::Sink, None),
                 ),
                 input: None,

--- a/src/vmm/src/devices/legacy/i8042.rs
+++ b/src/vmm/src/devices/legacy/i8042.rs
@@ -7,7 +7,7 @@
 
 use std::io;
 use std::num::Wrapping;
-use std::sync::{Arc, Barrier};
+use std::sync::{Arc, Barrier, RwLock};
 
 use serde::Serialize;
 use vmm_sys_util::eventfd::EventFd;
@@ -27,7 +27,7 @@ pub enum I8042Error {
 }
 
 /// Metrics specific to the i8042 device.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Default, Serialize)]
 pub(super) struct I8042DeviceMetrics {
     /// Errors triggered while using the i8042 device.
     error_count: SharedIncMetric,
@@ -42,22 +42,14 @@ pub(super) struct I8042DeviceMetrics {
     /// Bytes written by this device.
     write_count: SharedIncMetric,
 }
-impl I8042DeviceMetrics {
-    /// Const default construction.
-    const fn new() -> Self {
-        Self {
-            error_count: SharedIncMetric::new(),
-            missed_read_count: SharedIncMetric::new(),
-            missed_write_count: SharedIncMetric::new(),
-            read_count: SharedIncMetric::new(),
-            reset_count: SharedIncMetric::new(),
-            write_count: SharedIncMetric::new(),
-        }
-    }
-}
 
-/// Stores aggregated metrics
-pub(super) static METRICS: I8042DeviceMetrics = I8042DeviceMetrics::new();
+/// Stores the metrics of the (single) i8042 device.
+///
+/// The device owns its `Arc<I8042DeviceMetrics>` and registers a clone here on construction, so
+/// that `flush_metrics` can serialize them without reaching into the device. Keeping the metrics
+/// off a process-wide global lets unit tests, which each build their own device, run in parallel
+/// without clobbering each other's counters.
+pub(super) static METRICS: RwLock<Option<Arc<I8042DeviceMetrics>>> = RwLock::new(None);
 
 /// Offset of the status port (port 0x64)
 const OFS_STATUS: u64 = 4;
@@ -115,11 +107,17 @@ pub struct I8042Device {
     buf: [u8; BUF_SIZE],
     bhead: Wrapping<usize>,
     btail: Wrapping<usize>,
+
+    /// Metrics for this device, also registered in the module-level `METRICS`.
+    metrics: Arc<I8042DeviceMetrics>,
 }
 
 impl I8042Device {
     /// Constructs an i8042 device that will signal the given event when the guest requests it.
     pub fn new(reset_evt: EventFd) -> Result<I8042Device, std::io::Error> {
+        let metrics = Arc::new(I8042DeviceMetrics::default());
+        // A microVM only ever has one i8042 device, so replacing the slot is fine.
+        let _ = METRICS.write().unwrap().replace(metrics.clone());
         Ok(I8042Device {
             reset_evt,
             kbd_interrupt_evt: EventFd::new(libc::EFD_NONBLOCK)?,
@@ -130,6 +128,7 @@ impl I8042Device {
             buf: [0; BUF_SIZE],
             bhead: Wrapping(0),
             btail: Wrapping(0),
+            metrics,
         })
     }
 
@@ -214,7 +213,7 @@ impl BusDevice for I8042Device {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         // All our ports are byte-wide. We don't know how to handle any wider data.
         if data.len() != 1 {
-            METRICS.missed_read_count.inc();
+            self.metrics.missed_read_count.inc();
             return;
         }
 
@@ -239,16 +238,16 @@ impl BusDevice for I8042Device {
             _ => read_ok = false,
         }
         if read_ok {
-            METRICS.read_count.add(data.len() as u64);
+            self.metrics.read_count.add(data.len() as u64);
         } else {
-            METRICS.missed_read_count.inc();
+            self.metrics.missed_read_count.inc();
         }
     }
 
     fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
         // All our ports are byte-wide. We don't know how to handle any wider data.
         if data.len() != 1 {
-            METRICS.missed_write_count.inc();
+            self.metrics.missed_write_count.inc();
             return None;
         }
 
@@ -261,9 +260,9 @@ impl BusDevice for I8042Device {
                 // thread wakes up to handle this event.
                 if let Err(err) = self.reset_evt.write(1) {
                     error!("Failed to trigger i8042 reset event: {:?}", err);
-                    METRICS.error_count.inc();
+                    self.metrics.error_count.inc();
                 }
-                METRICS.reset_count.inc();
+                self.metrics.reset_count.inc();
             }
             OFS_STATUS if data[0] == CMD_READ_CTR => {
                 // The guest wants to read the control register.
@@ -331,9 +330,9 @@ impl BusDevice for I8042Device {
         }
 
         if write_ok {
-            METRICS.write_count.inc();
+            self.metrics.write_count.inc();
         } else {
-            METRICS.missed_write_count.inc();
+            self.metrics.missed_write_count.inc();
         }
 
         None
@@ -375,8 +374,7 @@ mod tests {
         i8042.read(0x0, 1, &mut data);
         assert_eq!(data[0], CMD_RESET_CPU);
 
-        // Check invalid `write`s.
-        let before = METRICS.missed_write_count.count();
+        // Check invalid `write`s. The device is freshly built, so the counter starts at 0.
         // offset != 0.
         i8042.write(0x0, 1, &data);
         // data != CMD_RESET_CPU
@@ -385,7 +383,7 @@ mod tests {
         // data.len() != 1
         let data = [CMD_RESET_CPU; 2];
         i8042.write(0x0, 1, &data);
-        assert_eq!(METRICS.missed_write_count.count(), before + 3);
+        assert_eq!(i8042.metrics.missed_write_count.count(), 3);
     }
 
     #[test]
@@ -529,5 +527,20 @@ mod tests {
             i8042.trigger_kbd_interrupt().unwrap_err(),
             I8042Error::KbdInterruptDisabled
         )
+    }
+
+    #[test]
+    fn test_i8042_metrics() {
+        let metrics = I8042DeviceMetrics::default();
+        metrics.read_count.add(2);
+        metrics.write_count.inc();
+        metrics.error_count.inc();
+
+        let serialized = serde_json::to_string(&metrics).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.get("read_count").and_then(|v| v.as_u64()), Some(2));
+        assert_eq!(obj.get("write_count").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(obj.get("error_count").and_then(|v| v.as_u64()), Some(1));
     }
 }

--- a/src/vmm/src/devices/legacy/mod.rs
+++ b/src/vmm/src/devices/legacy/mod.rs
@@ -63,11 +63,21 @@ impl EventFdTrigger {
 }
 
 /// Called by METRICS.flush(), this function facilitates serialization of aggregated metrics.
+///
+/// The i8042 and RTC devices own their metrics (registered in their module-level `METRICS` slot on
+/// construction); when no device has been built yet we serialize a default instance to keep the
+/// output shape stable. The UART still uses a module-global metrics object.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let mut seq = serializer.serialize_map(Some(1))?;
-    seq.serialize_entry("i8042", &i8042::METRICS)?;
+    match i8042::METRICS.read().unwrap().as_ref() {
+        Some(metrics) => seq.serialize_entry("i8042", metrics)?,
+        None => seq.serialize_entry("i8042", &i8042::I8042DeviceMetrics::default())?,
+    }
     #[cfg(target_arch = "aarch64")]
-    seq.serialize_entry("rtc", &rtc_pl031::METRICS)?;
+    match rtc_pl031::METRICS.read().unwrap().as_ref() {
+        Some(metrics) => seq.serialize_entry("rtc", metrics)?,
+        None => seq.serialize_entry("rtc", &rtc_pl031::RTCDeviceMetrics::default())?,
+    }
     seq.serialize_entry("uart", &serial::METRICS)?;
     seq.end()
 }

--- a/src/vmm/src/devices/legacy/mod.rs
+++ b/src/vmm/src/devices/legacy/mod.rs
@@ -64,9 +64,9 @@ impl EventFdTrigger {
 
 /// Called by METRICS.flush(), this function facilitates serialization of aggregated metrics.
 ///
-/// The i8042 and RTC devices own their metrics (registered in their module-level `METRICS` slot on
+/// Each legacy device owns its metrics (registered in its module-level `METRICS` slot on
 /// construction); when no device has been built yet we serialize a default instance to keep the
-/// output shape stable. The UART still uses a module-global metrics object.
+/// output shape stable.
 pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
     let mut seq = serializer.serialize_map(Some(1))?;
     match i8042::METRICS.read().unwrap().as_ref() {
@@ -78,6 +78,9 @@ pub fn flush_metrics<S: Serializer>(serializer: S) -> Result<S::Ok, S::Error> {
         Some(metrics) => seq.serialize_entry("rtc", metrics)?,
         None => seq.serialize_entry("rtc", &rtc_pl031::RTCDeviceMetrics::default())?,
     }
-    seq.serialize_entry("uart", &serial::METRICS)?;
+    match serial::METRICS.read().unwrap().as_ref() {
+        Some(metrics) => seq.serialize_entry("uart", metrics)?,
+        None => seq.serialize_entry("uart", &serial::SerialDeviceMetrics::default())?,
+    }
     seq.end()
 }

--- a/src/vmm/src/devices/legacy/rtc_pl031.rs
+++ b/src/vmm/src/devices/legacy/rtc_pl031.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::convert::TryInto;
+use std::sync::{Arc, RwLock};
 
 use serde::Serialize;
 use vm_superio::Rtc;
@@ -20,17 +21,6 @@ pub struct RTCDeviceMetrics {
     pub missed_write_count: SharedIncMetric,
 }
 
-impl RTCDeviceMetrics {
-    /// Const default construction.
-    pub const fn new() -> Self {
-        Self {
-            error_count: SharedIncMetric::new(),
-            missed_read_count: SharedIncMetric::new(),
-            missed_write_count: SharedIncMetric::new(),
-        }
-    }
-}
-
 impl RtcEvents for RTCDeviceMetrics {
     fn invalid_read(&self) {
         self.missed_read_count.inc();
@@ -45,26 +35,24 @@ impl RtcEvents for RTCDeviceMetrics {
     }
 }
 
-impl RtcEvents for &'static RTCDeviceMetrics {
-    fn invalid_read(&self) {
-        RTCDeviceMetrics::invalid_read(self);
-    }
-
-    fn invalid_write(&self) {
-        RTCDeviceMetrics::invalid_write(self);
-    }
-}
-
-/// Stores aggregated metrics
-pub static METRICS: RTCDeviceMetrics = RTCDeviceMetrics::new();
+/// Stores the metrics of the (single) RTC device.
+///
+/// The device owns its `Arc<RTCDeviceMetrics>` (via the inner `Rtc`, which `vm-superio` implements
+/// `RtcEvents` for `Arc<EV>`) and registers a clone here on construction, so that `flush_metrics`
+/// can serialize them. Keeping the metrics off a process-wide global lets unit tests, which each
+/// build their own device, run in parallel without clobbering each other's counters.
+pub static METRICS: RwLock<Option<Arc<RTCDeviceMetrics>>> = RwLock::new(None);
 
 /// Wrapper over vm_superio's RTC implementation.
 #[derive(Debug)]
-pub struct RTCDevice(vm_superio::Rtc<&'static RTCDeviceMetrics>);
+pub struct RTCDevice(vm_superio::Rtc<Arc<RTCDeviceMetrics>>);
 
 impl Default for RTCDevice {
     fn default() -> Self {
-        RTCDevice(Rtc::with_events(&METRICS))
+        let metrics = Arc::new(RTCDeviceMetrics::default());
+        // A microVM only ever has one RTC device, so replacing the slot is fine.
+        let _ = METRICS.write().unwrap().replace(metrics.clone());
+        RTCDevice(Rtc::with_events(metrics))
     }
 }
 
@@ -75,7 +63,7 @@ impl RTCDevice {
 }
 
 impl std::ops::Deref for RTCDevice {
-    type Target = vm_superio::Rtc<&'static RTCDeviceMetrics>;
+    type Target = vm_superio::Rtc<Arc<RTCDeviceMetrics>>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -101,7 +89,7 @@ impl RTCDevice {
                 offset,
                 data.len()
             );
-            METRICS.error_count.inc();
+            self.0.events().error_count.inc();
         }
     }
 
@@ -116,7 +104,7 @@ impl RTCDevice {
                 offset,
                 data.len()
             );
-            METRICS.error_count.inc();
+            self.0.events().error_count.inc();
         }
     }
 }
@@ -145,27 +133,29 @@ mod tests {
     use super::*;
     use crate::logger::IncMetric;
 
+    /// Build an `RTCDevice` backed by a caller-owned metrics instance, bypassing the module-level
+    /// `METRICS` registration so each test observes only its own counters.
+    fn build_test_rtc(metrics: Arc<RTCDeviceMetrics>) -> RTCDevice {
+        RTCDevice(Rtc::with_events(metrics))
+    }
+
     #[test]
-    fn test_rtc_device() {
-        static TEST_RTC_DEVICE_METRICS: RTCDeviceMetrics = RTCDeviceMetrics::new();
-        let mut rtc_pl031 = RTCDevice(Rtc::with_events(&TEST_RTC_DEVICE_METRICS));
+    fn test_rtc_device_invalid_write() {
+        let metrics = Arc::new(RTCDeviceMetrics::default());
+        let mut rtc_pl031 = build_test_rtc(metrics.clone());
         let data = [0; 4];
 
         // Write to the DR register. Since this is a RO register, the write
-        // function should fail.
-        let invalid_writes_before = TEST_RTC_DEVICE_METRICS.missed_write_count.count();
-        let error_count_before = TEST_RTC_DEVICE_METRICS.error_count.count();
+        // function should fail. The device is freshly built, so the counters start at 0.
         rtc_pl031.bus_write(0x000, &data);
-        let invalid_writes_after = TEST_RTC_DEVICE_METRICS.missed_write_count.count();
-        let error_count_after = TEST_RTC_DEVICE_METRICS.error_count.count();
-        assert_eq!(invalid_writes_after - invalid_writes_before, 1);
-        assert_eq!(error_count_after - error_count_before, 1);
+        assert_eq!(metrics.missed_write_count.count(), 1);
+        assert_eq!(metrics.error_count.count(), 1);
     }
 
     #[test]
     fn test_rtc_invalid_buf_len() {
-        static TEST_RTC_INVALID_BUF_LEN_METRICS: RTCDeviceMetrics = RTCDeviceMetrics::new();
-        let mut rtc_pl031 = RTCDevice(Rtc::with_events(&TEST_RTC_INVALID_BUF_LEN_METRICS));
+        let metrics = Arc::new(RTCDeviceMetrics::default());
+        let mut rtc_pl031 = build_test_rtc(metrics);
         let write_data_good = 123u32.to_le_bytes();
         let mut data_bad = [0; 2];
         let mut read_data_good = [0; 4];
@@ -176,5 +166,21 @@ mod tests {
         rtc_pl031.bus_read(0x008, &mut data_bad);
         assert_eq!(u32::from_le_bytes(read_data_good), 123);
         assert_eq!(u16::from_le_bytes(data_bad), 0);
+    }
+
+    #[test]
+    fn test_rtc_dev_metrics() {
+        let metrics = RTCDeviceMetrics::default();
+        metrics.error_count.inc();
+        metrics.missed_read_count.add(2);
+
+        let serialized = serde_json::to_string(&metrics).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.get("error_count").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(
+            obj.get("missed_read_count").and_then(|v| v.as_u64()),
+            Some(2)
+        );
     }
 }

--- a/src/vmm/src/devices/legacy/serial.rs
+++ b/src/vmm/src/devices/legacy/serial.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 use std::fs::File;
 use std::io::{self, Read, Stdin, Write};
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::sync::{Arc, Barrier};
+use std::sync::{Arc, Barrier, RwLock};
 
 use event_manager::{EventOps, Events, MutEventSubscriber};
 use libc::EFD_NONBLOCK;
@@ -44,23 +44,14 @@ pub struct SerialDeviceMetrics {
     /// Total bytes dropped by the serial output rate limiter.
     pub rate_limiter_dropped_bytes: SharedIncMetric,
 }
-impl SerialDeviceMetrics {
-    /// Const default construction.
-    pub const fn new() -> Self {
-        Self {
-            error_count: SharedIncMetric::new(),
-            flush_count: SharedIncMetric::new(),
-            missed_read_count: SharedIncMetric::new(),
-            missed_write_count: SharedIncMetric::new(),
-            read_count: SharedIncMetric::new(),
-            write_count: SharedIncMetric::new(),
-            rate_limiter_dropped_bytes: SharedIncMetric::new(),
-        }
-    }
-}
 
-/// Stores aggregated metrics
-pub(super) static METRICS: SerialDeviceMetrics = SerialDeviceMetrics::new();
+/// Stores the metrics of the (single) UART device.
+///
+/// The device owns its `Arc<SerialDeviceMetrics>` and registers a clone here on construction, so
+/// that `flush_metrics` can serialize them without reaching into the device. Keeping the metrics
+/// off a process-wide global lets unit tests, which each build their own device, run in parallel
+/// without clobbering each other's counters.
+pub(super) static METRICS: RwLock<Option<Arc<SerialDeviceMetrics>>> = RwLock::new(None);
 
 #[derive(Debug, thiserror::Error, displaydoc::Display)]
 pub enum RawIOError {
@@ -93,21 +84,36 @@ impl<EV: SerialEvents + Debug, W: Write + Debug> RawIOHandler for Serial<EventFd
 /// Wrapper over available events (i.e metrics, buffer ready etc).
 #[derive(Debug)]
 pub struct SerialEventsWrapper {
+    /// Metrics for the device this wrapper belongs to.
+    pub metrics: Arc<SerialDeviceMetrics>,
     /// Buffer ready event.
     pub buffer_ready_event_fd: Option<EventFdTrigger>,
 }
 
+impl SerialEventsWrapper {
+    /// Create a `SerialEventsWrapper` backed by the given metrics and buffer-ready event.
+    pub fn new(
+        metrics: Arc<SerialDeviceMetrics>,
+        buffer_ready_event_fd: Option<EventFdTrigger>,
+    ) -> Self {
+        Self {
+            metrics,
+            buffer_ready_event_fd,
+        }
+    }
+}
+
 impl SerialEvents for SerialEventsWrapper {
     fn buffer_read(&self) {
-        METRICS.read_count.inc();
+        self.metrics.read_count.inc();
     }
 
     fn out_byte(&self) {
-        METRICS.write_count.inc();
+        self.metrics.write_count.inc();
     }
 
     fn tx_lost_byte(&self) {
-        METRICS.missed_write_count.inc();
+        self.metrics.missed_write_count.inc();
     }
 
     fn in_buffer_empty(&self) {
@@ -139,6 +145,13 @@ pub struct SerialOut {
     inner: SerialOutInner,
     /// Optional rate limiter for serial output bandwidth.
     rate_limiter: Option<TokenBucket>,
+    /// Metrics for the device this output belongs to.
+    ///
+    /// A `SerialOut` is created by the caller before the owning `SerialDevice` exists, so it starts
+    /// with a private default instance; `SerialDevice::new` swaps in the shared, registered metrics
+    /// via [`SerialOut::set_metrics`] so the rate-limiter counter lands in the same place as the
+    /// rest of the device's metrics.
+    metrics: Arc<SerialDeviceMetrics>,
 }
 
 impl SerialOut {
@@ -147,7 +160,13 @@ impl SerialOut {
         Self {
             inner,
             rate_limiter,
+            metrics: Arc::new(SerialDeviceMetrics::default()),
         }
+    }
+
+    /// Point this output's metrics at the device's shared, registered instance.
+    pub fn set_metrics(&mut self, metrics: Arc<SerialDeviceMetrics>) {
+        self.metrics = metrics;
     }
 }
 
@@ -161,7 +180,7 @@ impl std::io::Write for SerialOut {
         if let Some(ref mut rl) = self.rate_limiter {
             match rl.reduce(usize_to_u64(buf.len())) {
                 BucketReduction::Failure | BucketReduction::OverConsumption(_) => {
-                    METRICS
+                    self.metrics
                         .rate_limiter_dropped_bytes
                         .add(usize_to_u64(buf.len()));
                     return Ok(buf.len());
@@ -267,14 +286,19 @@ pub type SerialDevice = SerialWrapper<EventFdTrigger, SerialEventsWrapper, Stdin
 impl SerialDevice {
     pub fn new(
         serial_in: Option<Stdin>,
-        serial_out: SerialOut,
+        mut serial_out: SerialOut,
         state: Option<&SerialState>,
     ) -> Result<Self, std::io::Error> {
         let interrupt_evt = EventFdTrigger::new(EventFd::new(EFD_NONBLOCK)?);
         let buffer_read_event_fd = EventFdTrigger::new(EventFd::new(EFD_NONBLOCK)?);
-        let events = SerialEventsWrapper {
-            buffer_ready_event_fd: Some(buffer_read_event_fd),
-        };
+
+        let metrics = Arc::new(SerialDeviceMetrics::default());
+        // A microVM only ever has one UART device, so replacing the slot is fine.
+        let _ = METRICS.write().unwrap().replace(metrics.clone());
+        // The output was built by the caller with its own default metrics; point it at the shared
+        // instance so the rate-limiter counter is aggregated with the rest.
+        serial_out.set_metrics(metrics.clone());
+        let events = SerialEventsWrapper::new(metrics, Some(buffer_read_event_fd));
 
         let serial =
             match state {
@@ -416,7 +440,7 @@ where
         if let (Ok(offset), 1) = (u8::try_from(offset), data.len()) {
             data[0] = self.serial.read(offset);
         } else {
-            METRICS.missed_read_count.inc();
+            self.serial.events().metrics.missed_read_count.inc();
         }
     }
 
@@ -425,10 +449,10 @@ where
             if let Err(err) = self.serial.write(offset, data[0]) {
                 // Counter incremented for any handle_write() error.
                 error!("Failed the write to serial: {:?}", err);
-                METRICS.error_count.inc();
+                self.serial.events().metrics.error_count.inc();
             }
         } else {
-            METRICS.missed_write_count.inc();
+            self.serial.events().metrics.missed_write_count.inc();
         }
         None
     }
@@ -453,34 +477,30 @@ mod tests {
     fn test_serial_bus_read() {
         let intr_evt = EventFdTrigger::new(EventFd::new(libc::EFD_NONBLOCK).unwrap());
 
-        let metrics = &METRICS;
-
+        // Build the device with a caller-owned metrics instance so the test observes only its own
+        // counters, independent of any other device or test.
+        let metrics = Arc::new(SerialDeviceMetrics::default());
         let mut serial = SerialDevice {
             serial: Serial::with_events(
                 intr_evt,
-                SerialEventsWrapper {
-                    buffer_ready_event_fd: None,
-                },
+                SerialEventsWrapper::new(metrics.clone(), None),
                 test_serial_out_sink(),
             ),
             input: None::<std::io::Stdin>,
         };
         serial.serial.raw_input(b"abc").unwrap();
 
-        let invalid_reads_before = metrics.missed_read_count.count();
+        // The device is freshly built, so the counter starts at 0.
         let mut v = [0x00; 2];
         serial.read(0x0, 0u64, &mut v);
-
-        let invalid_reads_after = metrics.missed_read_count.count();
-        assert_eq!(invalid_reads_before + 1, invalid_reads_after);
+        assert_eq!(metrics.missed_read_count.count(), 1);
 
         let mut v = [0x00; 1];
         serial.read(0x0, 0u64, &mut v);
         assert_eq!(v[0], b'a');
 
-        let invalid_reads_after_2 = metrics.missed_read_count.count();
-        // The `invalid_read_count` metric should be the same as before the one-byte reads.
-        assert_eq!(invalid_reads_after_2, invalid_reads_after);
+        // A valid one-byte read must not bump the missed-read counter.
+        assert_eq!(metrics.missed_read_count.count(), 1);
     }
 
     #[test]
@@ -522,15 +542,17 @@ mod tests {
 
     #[test]
     fn test_serial_dev_metrics() {
-        let serial_metrics: SerialDeviceMetrics = SerialDeviceMetrics::new();
-        let serial_metrics_local: String = serde_json::to_string(&serial_metrics).unwrap();
-        // the 1st serialize flushes the metrics and resets values to 0 so that
-        // we can compare the values with local metrics.
-        serde_json::to_string(&METRICS).unwrap();
-        let serial_metrics_global: String = serde_json::to_string(&METRICS).unwrap();
-        assert_eq!(serial_metrics_local, serial_metrics_global);
-        serial_metrics.read_count.inc();
-        assert_eq!(serial_metrics.read_count.count(), 1);
+        let metrics = SerialDeviceMetrics::default();
+        metrics.read_count.inc();
+        metrics.write_count.add(3);
+        metrics.error_count.inc();
+
+        let serialized = serde_json::to_string(&metrics).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let obj = json.as_object().unwrap();
+        assert_eq!(obj.get("read_count").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(obj.get("write_count").and_then(|v| v.as_u64()), Some(3));
+        assert_eq!(obj.get("error_count").and_then(|v| v.as_u64()), Some(1));
     }
 
     #[test]
@@ -566,12 +588,11 @@ mod tests {
         let result = serial_out.write(b"abcd").unwrap();
         assert_eq!(result, 4);
 
-        let dropped_before = METRICS.rate_limiter_dropped_bytes.count();
+        // A freshly built `SerialOut` owns its own metrics, so the counter starts at 0.
         let big_data = vec![b'X'; 1024];
         let result = serial_out.write(&big_data).unwrap();
         assert_eq!(result, 1024);
-        let dropped_delta = METRICS.rate_limiter_dropped_bytes.count() - dropped_before;
-        assert!(dropped_delta >= 1024);
+        assert!(serial_out.metrics.rate_limiter_dropped_bytes.count() >= 1024);
 
         use std::io::Seek;
         let mut file = file;
@@ -584,9 +605,9 @@ mod tests {
     #[test]
     fn test_serial_out_sink_discards_everything() {
         let mut serial_out = test_serial_out_sink();
-        let dropped_before = METRICS.rate_limiter_dropped_bytes.count();
         let result = serial_out.write(b"anything").unwrap();
         assert_eq!(result, 8);
-        assert_eq!(METRICS.rate_limiter_dropped_bytes.count(), dropped_before);
+        // A sink with no rate limiter never drops bytes.
+        assert_eq!(serial_out.metrics.rate_limiter_dropped_bytes.count(), 0);
     }
 }

--- a/src/vmm/tests/devices.rs
+++ b/src/vmm/tests/devices.rs
@@ -13,7 +13,7 @@ use std::sync::{Arc, Mutex};
 use event_manager::{EventManager, SubscriberOps};
 use libc::EFD_NONBLOCK;
 use vm_superio::Serial;
-use vmm::devices::legacy::serial::{SerialOut, SerialOutInner};
+use vmm::devices::legacy::serial::{SerialDeviceMetrics, SerialOut, SerialOutInner};
 use vmm::devices::legacy::{EventFdTrigger, SerialEventsWrapper, SerialWrapper};
 use vmm::vstate::bus::BusDevice;
 use vmm_sys_util::eventfd::EventFd;
@@ -28,9 +28,10 @@ fn create_serial(
     Arc::new(Mutex::new(SerialWrapper {
         serial: Serial::with_events(
             EventFdTrigger::new(EventFd::new(EFD_NONBLOCK).unwrap()),
-            SerialEventsWrapper {
-                buffer_ready_event_fd: Some(kick_stdin_evt.try_clone().unwrap()),
-            },
+            SerialEventsWrapper::new(
+                Arc::new(SerialDeviceMetrics::default()),
+                Some(kick_stdin_evt.try_clone().unwrap()),
+            ),
             SerialOut::new(SerialOutInner::Stdout(std::io::stdout()), None),
         ),
         input: Some(Box::new(serial_in)),


### PR DESCRIPTION
## Changes

Moves the **serial (UART)** device off its module-global metrics static to the per-device metrics model, completing the legacy-device conversion started in #6190 (i8042 + RTC).

The UART is trickier than i8042/RTC because its metrics are touched from three places, so the device's `Arc<SerialDeviceMetrics>` is threaded to each:

- `SerialEventsWrapper` gains a private `metrics` field and a `new()` constructor; its `SerialEvents` impl increments through it.
- `SerialOut` is built by the caller *before* the owning `SerialDevice` exists, so it starts with a private default metrics instance; `SerialDevice::new` swaps in the shared, registered instance via `set_metrics` so the rate-limiter counter aggregates with the rest.
- The `BusDevice` impl reaches the metrics via `self.serial.events().metrics`.

`legacy::flush_metrics` serializes the registered UART instance (falling back to a `default()` when none has been built), so **the serialized metrics output shape is unchanged**.

## Stacking

> This is **stacked on #6190**. The first commit here is #6190 (i8042 + RTC); the second is the UART work. Please merge #6190 first, after which this reduces to just the UART commit. Happy to rebase/split however is easiest to review.

## Why

Another step towards #4709. With all three legacy devices (i8042, RTC, UART) off the process-wide metrics global, their unit tests can build isolated per-device metrics and run concurrently. This PR still does **not** flip `RUST_TEST_THREADS=1` — that stays until the remaining logger globals (mmds, msix) are converted.

## Testing

Built and tested in the `fcuvm:v93` dev container (x86_64):

- `cargo build -p vmm` — clean
- `cargo clippy -p vmm --all-targets` — no warnings
- `cargo fmt --check` — clean (no lines >100 chars, safe under nightly `wrap_comments`)
- `cargo test -p vmm devices::legacy` — 12 passed (i8042 + serial)
- `cargo test -p vmm --test devices` (external integration test) — 3 passed
- `cargo test -p vmm devices::legacy -- --test-threads=16`, 3 consecutive runs — 12 passed / 0 failed each, confirming parallel-safety

Related: #4709