### PR TITLE
Improve A/B tests

### DIFF
--- a/.buildkite/common.py
+++ b/.buildkite/common.py
@@ -309,10 +309,13 @@ class BKPipeline:
     def __init__(self, with_build_step=True, **kwargs):
         self.steps = []
         self.args = args = self.parser.parse_args()
-        # Retry one time if agent was lost. This can happen if we terminate the
-        # instance or the agent gets disconnected for whatever reason
         retry = {
-            "automatic": [{"exit_status": -1, "limit": 1}],
+            "automatic": [
+                # Not retrying automatically in case of timeouts, regardless of exit status
+                {"signal_reason": "cancel", "limit": 0},
+                # Retrying once if Buildkite lost contact with the agent, or it stopped reporting
+                {"exit_status": -1, "limit": 1},
+            ],
         }
         retry = overlay_dict(retry, kwargs.pop("retry", {}))
         # Calculate step defaults with parameters and kwargs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -235,7 +235,7 @@ def metrics(results_dir, request):
     yield metrics_logger
     metrics_logger.flush()
     if results_dir:
-        metrics_logger.store_data(results_dir)
+        metrics_logger.store_data(results_dir, nodeid=request.node.nodeid)
 
 
 @pytest.fixture

--- a/tests/host_tools/metrics.py
+++ b/tests/host_tools/metrics.py
@@ -87,14 +87,21 @@ class MetricsWrapper:
         if self.logger:
             asyncio.run(self.logger.flush())
 
-    def store_data(self, dir_path):
-        """Store data into a file"""
+    def store_data(self, dir_path, nodeid=None):
+        """Store data into a file
+
+        `nodeid` is the pytest node id of the test that produced these metrics.
+        It is written as a standalone field (not as a CloudWatch dimension), so
+        it does not affect the emitted CloudWatch metrics. It lets consumers
+        (e.g. the A/B test runner) map a metric back to a runnable pytest test.
+        """
         metrics_path = Path(dir_path / "metrics.json")
         with open(metrics_path, "w", encoding="utf-8") as f:
             json.dump(
                 {
                     "metrics": self.metrics,
                     "dimensions": self.dimensions,
+                    "nodeid": nodeid,
                 },
                 f,
             )

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -471,8 +471,10 @@ def ab_performance_test(
 
         if i < max_iterations - 1:
             print(
-                f"{len(error_messages)} regression(s) detected, retrying to collect more data..."
+                f"{len(error_messages)} regression(s) detected as of iteration {i + 1}/{max_iterations}:"
             )
+            print("\n".join(error_messages))
+            print("Retrying to collect more data...")
 
     assert not error_messages, "\n" + "\n".join(error_messages)
 

--- a/tools/ab_test.py
+++ b/tools/ab_test.py
@@ -20,6 +20,7 @@ import argparse
 import glob
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import time
@@ -147,8 +148,14 @@ def is_ignored(dimensions) -> bool:
 
 
 def load_data_series(data_path: Path):
-    """Recursively collects `metrics.json` files in provided path"""
+    """Recursively collects `metrics.json` files in provided path
+
+    Returns a tuple `(data, nodeids)` where `data` maps each dimension set to
+    its metrics, and `nodeids` maps each dimension set to the pytest node id
+    that produced it (when recorded), so callers can re-run specific tests.
+    """
     data = {}
+    nodeids = {}
     pattern = f"{glob.escape(str(data_path))}/**/metrics.json"
     for name in glob.glob(pattern, recursive=True):
         with open(name, encoding="utf-8") as f:
@@ -156,6 +163,11 @@ def load_data_series(data_path: Path):
 
         metrics = j["metrics"]
         dimensions = frozenset(j["dimensions"].items())
+
+        nodeid = j.get("nodeid")
+        # Keep support for no nodeid, so old metrics can be analyzed
+        if nodeid is not None:
+            nodeids[dimensions] = nodeid
 
         data[dimensions] = {}
         for m in metrics:
@@ -167,7 +179,7 @@ def load_data_series(data_path: Path):
             values = mm["values"]
             data[dimensions][m] = (values, unit)
 
-    return data
+    return data, nodeids
 
 
 def uninteresting_dimensions(data):
@@ -196,10 +208,17 @@ def collect_data(
     artifacts: Optional[Path],
     pytest_opts: str,
     iteration: int = 0,
+    nodeids: Optional[List[str]] = None,
 ):
     """
     Executes the specified test using the provided firecracker binaries and
     stores results into the `test_results/tag/iteration` directory
+
+    If `nodeids` is provided, it replaces the `pytest_opts` selection and only
+    those exact pytest node ids are executed. This is used on retry iterations
+    to re-run just the test cases that showed a regression, instead of the
+    whole selection. Node ids are already exact, so any `-k` filter in the
+    original `pytest_opts` would be redundant.
     """
     binary_dir = binary_dir.resolve()
 
@@ -222,8 +241,15 @@ def collect_data(
             f"./tools/devtool set_current_artifacts {artifacts}", check=True, shell=True
         )
 
+    if nodeids:
+        # Replace the selection with the exact failing node ids, shell-quoted
+        # since they contain characters like '[', ']' and '::'.
+        selection = " ".join(shlex.quote(nodeid) for nodeid in nodeids)
+    else:
+        selection = pytest_opts
+
     subprocess.run(
-        f"./tools/test.sh --binary-dir={binary_dir} {pytest_opts} -m '' --json-report-file=../{test_report_path}",
+        f"./tools/test.sh --binary-dir={binary_dir} {selection} -m '' --json-report-file=../{test_report_path}",
         env=os.environ,
         check=True,
         shell=True,
@@ -294,7 +320,10 @@ def analyze_data(
     Analyzes the A/B-test data produced by `collect_data`, by performing regression tests
     as described this script's doc-comment.
 
-    Returns the list of error messages (empty if the test passes).
+    Returns a tuple `(error_messages, failing_dimensions)` where `error_messages`
+    is the list of human-readable regression descriptions (empty if the test
+    passes) and `failing_dimensions` is the set of dimension sets that produced
+    those messages, so callers can re-run just the offending test cases.
     """
     assert set(data_a.keys()) == set(
         data_b.keys()
@@ -384,6 +413,7 @@ def analyze_data(
             )
 
     error_messages = []
+    failing_dimensions = set()
     do_not_print_list = uninteresting_dimensions(data_a)
     for dimension_set, metric, result, unit in failures:
         # No data points for this metric were deemed significant
@@ -409,8 +439,9 @@ def analyze_data(
                 f"Tested Dimensions:\n{json.dumps({k: v for k, v in dimension_set if k not in do_not_print_list}, indent=2, sort_keys=True)}"
             )
             error_messages.append(msg)
+            failing_dimensions.add(dimension_set)
 
-    return error_messages
+    return error_messages, failing_dimensions
 
 
 def merge_data(accumulated, new_data):
@@ -438,26 +469,44 @@ def ab_performance_test(
 ):
     """Does an A/B-test of the specified test with the given firecracker/jailer binaries.
 
-    Retries up to max_iterations times, accumulating data only for dimensions
-    that are still failing, to reduce noise-induced false positives."""
+    Retries up to max_iterations times, re-running only the test cases that are
+    still failing and accumulating their data, to reduce noise-induced false
+    positives while avoiding re-running the entire selection every iteration."""
 
     data_a = {}
     data_b = {}
+    # Maps each dimension set to the pytest node id that produced it, so that
+    # retries can re-run only the failing test cases.
+    nodeids = {}
     error_messages = []
+    # Node ids to re-run on the next iteration. `None` means "run the full
+    # selection" (the first iteration, and any fallback when a failing
+    # dimension set has no recorded node id).
+    retry_nodeids = None
 
     for i in range(max_iterations):
         print(f"\n=== Iteration {i + 1}/{max_iterations} ===")
         # Changing the order or A and B executions across iterations, to avoid fluctuations caused by execution order
         if i % 2 == 0:
-            new_a = collect_data("A", a_directory, a_artifacts, pytest_opts, i)
-            new_b = collect_data("B", b_directory, b_artifacts, pytest_opts, i)
+            new_a, nodeids_a = collect_data(
+                "A", a_directory, a_artifacts, pytest_opts, i, nodeids=retry_nodeids
+            )
+            new_b, nodeids_b = collect_data(
+                "B", b_directory, b_artifacts, pytest_opts, i, nodeids=retry_nodeids
+            )
         else:
-            new_b = collect_data("B", b_directory, b_artifacts, pytest_opts, i)
-            new_a = collect_data("A", a_directory, a_artifacts, pytest_opts, i)
+            new_b, nodeids_b = collect_data(
+                "B", b_directory, b_artifacts, pytest_opts, i, nodeids=retry_nodeids
+            )
+            new_a, nodeids_a = collect_data(
+                "A", a_directory, a_artifacts, pytest_opts, i, nodeids=retry_nodeids
+            )
         merge_data(data_a, new_a)
         merge_data(data_b, new_b)
+        nodeids.update(nodeids_a)
+        nodeids.update(nodeids_b)
 
-        error_messages = analyze_data(
+        error_messages, failing_dimensions = analyze_data(
             data_a,
             data_b,
             p_thresh,
@@ -474,7 +523,22 @@ def ab_performance_test(
                 f"{len(error_messages)} regression(s) detected as of iteration {i + 1}/{max_iterations}:"
             )
             print("\n".join(error_messages))
-            print("Retrying to collect more data...")
+
+            # Re-run only the failing test cases on the next iteration. If any
+            # failing dimension set lacks a recorded node id, we cannot safely
+            # narrow the selection, so fall back to re-running everything.
+            missing = [dims for dims in failing_dimensions if dims not in nodeids]
+            if missing:
+                print(
+                    "Could not determine the pytest node id for every failing "
+                    "test case; re-running the full selection."
+                )
+                retry_nodeids = None
+            else:
+                retry_nodeids = sorted({nodeids[dims] for dims in failing_dimensions})
+                print(
+                    f"Retrying {len(retry_nodeids)} failing test case(s) to collect more data..."
+                )
 
     assert not error_messages, "\n" + "\n".join(error_messages)
 
@@ -582,12 +646,12 @@ def main():
         print(f"Total A/B test took {time.perf_counter() - t0:.2f}s")
     else:
         t0 = time.perf_counter()
-        data_a = load_data_series(args.path_a)
-        data_b = load_data_series(args.path_b)
+        data_a, _ = load_data_series(args.path_a)
+        data_b, _ = load_data_series(args.path_b)
         print(f"Data loading took {time.perf_counter() - t0:.2f}s")
 
         t0 = time.perf_counter()
-        error_messages = analyze_data(
+        error_messages, _ = analyze_data(
             data_a,
             data_b,
             p_thresh,


### PR DESCRIPTION
## Changes

Three changes that improve A/B tests:
 - print regressions at every iteration (rather than just the last). This will help in case the test was terminated earlier
 - avoid retries in case of timeouts. The retry was not the intent of the current retry strategy. See https://buildkite.com/docs/pipelines/configure/retry for the documentation, and https://buildkite.com/firecracker/performance-a-b-tests/builds/1015/waterfall?jid=01a039be-3246-469f-83d3-15b913e4d64c&tab=output for an example of a test that terminated due to a timeout, but with exit status -1
 - re-run only failed test cases in A/B test. This will speed up subsequent iterations when only a subset of all test cases regressed


Example of a run with these changes that retries: https://buildkite.com/firecracker/mamarang-nested-a-b/builds/224/list?sid=01a07cb9-04b8-4e88-a302-7d0f937a4a3a&tab=output  
You can see that : (1) in the first iteration, the regressions were printed, and (2) in the second iteration, only a subset of tests got retried.

## Reason

Lower A/B test runtime; improved troubleshooting.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle --no-clippy` to verify that the PR
  passes the automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
