### PR TITLE
ci: define a github action for style + build checks

### DIFF
--- a/.github/workflows/cache_devctr.yml
+++ b/.github/workflows/cache_devctr.yml
@@ -1,0 +1,75 @@
+name: Cache dev container
+
+# Keep a copy of the dev container image in the workflow cache so that
+# pull request checks load it from there instead of pulling it from the
+# registry, which rate limits anonymous pulls. The job is idempotent: it
+# exits early when the image for the current tag is already cached, so
+# running it on every devtool change is cheap. The weekly schedule keeps
+# the entry from being evicted for inactivity.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - tools/devtool
+      - .github/workflows/cache_devctr.yml
+  schedule:
+    - cron: "0 1 * * 6"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  cache_devctr:
+    name: Cache dev container
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: "Resolve dev container image"
+        id: image
+        run: |
+          image=$(./tools/devtool -y devctr_image)
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+          echo "key=fcuvm-${RUNNER_OS}-${RUNNER_ARCH}-${image##*:}" >> "$GITHUB_OUTPUT"
+
+      # A real restore rather than a lookup, so that the entry counts as
+      # accessed and is not evicted after a quiet week.
+      - name: "Restore cached image"
+        id: restore
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ runner.temp }}/fcuvm.tar.zst
+          key: ${{ steps.image.outputs.key }}
+
+      - name: "Pull dev container"
+        if: steps.restore.outputs.cache-hit != 'true'
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+        run: docker pull "$IMAGE"
+
+      - name: "Save image"
+        if: steps.restore.outputs.cache-hit != 'true'
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+        # `shell: bash` enables pipefail, so a failed `docker save` fails
+        # the step instead of caching a truncated archive.
+        shell: bash
+        run: docker save "$IMAGE" | zstd -T0 -o "$RUNNER_TEMP/fcuvm.tar.zst"
+
+      - name: "Cache image"
+        if: steps.restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ runner.temp }}/fcuvm.tar.zst
+          key: ${{ steps.image.outputs.key }}

--- a/.github/workflows/pr_style_and_build.yml
+++ b/.github/workflows/pr_style_and_build.yml
@@ -1,0 +1,31 @@
+name: PR style and build
+
+on: pull_request
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  style_and_build:
+    name: Style and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: "Checkout pull request head"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: "Check build"
+        run: ./tools/devtool -y checkbuild --all
+
+      - name: "Check style"
+        env:
+          BUILDKITE_PULL_REQUEST_BASE_BRANCH: ${{ github.base_ref }}
+        run: ./tools/devtool -y checkstyle --no-clippy

--- a/.github/workflows/pr_style_and_build.yml
+++ b/.github/workflows/pr_style_and_build.yml
@@ -22,6 +22,29 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Load the dev container from the cache that cache_devctr.yml keeps on
+      # main, so the checks below do not pull it from the registry. On a
+      # miss, devtool pulls the image itself, with retries.
+      - name: "Resolve dev container image"
+        id: image
+        run: |
+          image=$(./tools/devtool -y devctr_image)
+          echo "key=fcuvm-${RUNNER_OS}-${RUNNER_ARCH}-${image##*:}" >> "$GITHUB_OUTPUT"
+
+      - name: "Restore cached dev container"
+        id: restore
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ runner.temp }}/fcuvm.tar.zst
+          key: ${{ steps.image.outputs.key }}
+
+      - name: "Load dev container"
+        if: steps.restore.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          zstd -d -c "$RUNNER_TEMP/fcuvm.tar.zst" | docker load
+          rm -f "$RUNNER_TEMP/fcuvm.tar.zst"
+
       - name: "Check build"
         run: ./tools/devtool -y checkbuild --all
 

--- a/tools/devtool
+++ b/tools/devtool
@@ -298,6 +298,13 @@ cmd_build_devctr() {
     docker build -t "$DEVCTR_IMAGE_NO_TAG" -f "$docker_file_name" $build_args .
 }
 
+# Prints the development container image reference, so that other tooling
+# can pull, cache or inspect the exact image devtool would run.
+#
+cmd_devctr_image() {
+    echo "$DEVCTR_IMAGE"
+}
+
 
 # Validate the user supplied kernel version number.
 # It must be composed of 2 groups of integers separated by dot, with an optional third group.
@@ -428,6 +435,9 @@ cmd_help() {
     echo ""
     echo "    checkenv"
     echo "        Performs prerequisites checks needed to execute firecracker."
+    echo ""
+    echo "    devctr_image"
+    echo "        Print the development container image reference (name:tag)."
     echo ""
     echo "    distclean"
     echo "        Clean up the build tree and remove the docker container."

--- a/tools/devtool
+++ b/tools/devtool
@@ -208,14 +208,19 @@ retry_cmd() {
     {
         $command
     } || {
+        rc=$?
+
         # Command failed, substract one from retry_cnt
         retry_cnt=$((retry_cnt - 1))
 
-        # If retry_cnt is larger than 0, sleep and call again
+        # If retry_cnt is larger than 0, sleep and call again. Otherwise,
+        # give up and report the last failure.
         if [ "$retry_cnt" -gt 0 ]; then
             echo "$command failed, retrying..."
             sleep "$sleep_int"
             retry_cmd "$command" "$retry_cnt" "$sleep_int"
+        else
+            return $rc
         fi
     }
 }

--- a/tools/devtool
+++ b/tools/devtool
@@ -314,10 +314,13 @@ validate_kernel_version() {
 }
 
 
-# Helper function to run the dev container.
+# Helper function to run the dev container. Pulls the image first if it is
+# not available locally.
 # Usage: run_devctr <docker args> -- <container args>
 # Example: run_devctr --privileged -- bash -c "echo 'hello world'"
 run_devctr() {
+    ensure_devctr
+
     docker_args=()
     ctr_args=()
     docker_args_done=false
@@ -573,7 +576,6 @@ cmd_build() {
     done
 
     # Check prerequisites
-    ensure_devctr
     ensure_build_dir
 
     # Map the public and private keys to the guest if they are specified.
@@ -1013,7 +1015,6 @@ cmd_test() {
         acquire_shared_kvm_lock
         setup_kvm
     fi
-    ensure_devctr
     [ $do_build_dir_check != 0 ] && ensure_build_dir
     if [ $do_artifacts_check != 0 ]; then
       if [ -z $artifacts ]; then
@@ -1138,7 +1139,6 @@ cmd_shell() {
     done
 
     # Make sure we have what we need to continue.
-    ensure_devctr
     ensure_build_dir
 
     if [[ $privileged = true ]]; then
@@ -1436,9 +1436,6 @@ cmd_install() {
 }
 
 cmd_build_ci_artifacts() {
-    # Check prerequisites
-    ensure_devctr
-
     # We need to run nested Docker here, so run this container as privileged.
     run_devctr \
         --privileged \


### PR DESCRIPTION
## Changes

- Introduce a new GitHub Action that runs style + build checks. Runs without approval
- Cache the devctr image in the Actions cache so PR checks do not pull it from Public ECR on every run
- `tools/devtool`:
  - `retry_cmd` returns the last exit code when its retries are exhausted, instead of returning 0 and letting `docker run` attempt one more unretried pull
  - `run_devctr` calls `ensure_devctr`, so every command that runs the container (including `checkbuild`, `fmt`, `mkdocs`, `sh`) pulls the image with retries; the redundant per-command calls are dropped
  - new `devctr_image` command prints the resolved image reference, so CI can key the cache on it without parsing the script

## Reason

Rather commonly, PRs do not pass style or build checks in their first iteration. As maintainers we cannot detect this until we *manually* unblock the Buildkite pipeline run. This delays easily actionable feedback for contributors, and wastes maintainer attention, when the PR is not necessarily in a ready state. Additionally, the full build, functional and performance tests currently run on metal instances even when we know that the style checks have failed, this is expensive and wasteful. Now, when the Buildkite pipeline is unblocked, we can have a reasonable degree of confidence that the sanity checks have passed.

The first version of the action pulled the devctr from Public ECR on every run and hit ECR's anonymous pull rate limit (`toomanyrequests`). GitHub-hosted runners start from an empty Docker store and share egress, so this is expected to recur. The fix is to pull the image once per devctr tag from a trusted workflow on `main` and keep a `docker save` archive in the Actions cache:

- `cache_devctr.yml` runs on `main` when `tools/devtool` (or the workflow itself) changes, weekly, and on demand. It restores the entry for the current tag, and only if that misses pulls the image, `docker save | zstd`s it, and saves it under `fcuvm-<os>-<arch>-<tag>`. It is idempotent; a run on an unrelated `devtool` change exits after the restore.
- `pr_style_and_build.yml` derives the same key from the PR's own `devtool`, restores, `docker load`s on a hit, then runs `checkbuild --all` followed by `checkstyle --no-clippy`. Fork PRs can read caches created on `main` but cannot write them, so a PR cannot replace the image other checks use.
- On a cache miss (tag bump PR, evicted entry) nothing fails: `devtool` pulls the image as before, now with its retries actually working. The cache is an accelerator, not a dependency.

No credentials, mirrors, or infra changes are involved; only the built-in `GITHUB_TOKEN` and anonymous ECR pulls.

## Testing

- `docker save | zstd` / `zstd -d | docker load` round trip preserves the `public.ecr.aws/firecracker/fcuvm:v93` tag (4.3 GiB -> 1.3 GiB compressed).
- The caching has not yet run on this repository. Merging this PR should populate the cache, allowing re-use on the next PR.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle --no-clippy` to verify that the PR
  passes the automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [x] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
