### PR TITLE
tests: increase determinism of RateLimiter and TokenBucket unit tests

### DIFF
--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -10,6 +10,7 @@ bench = false
 
 [features]
 tracing = ["log-instrument"]
+test-utils = []
 
 [dependencies]
 displaydoc = "0.2.6"

--- a/src/utils/src/time.rs
+++ b/src/utils/src/time.rs
@@ -4,7 +4,7 @@
 use std::fs::File;
 use std::io::{ErrorKind, Read};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use std::{fmt, ptr};
 
 /// Constant to convert seconds to nanoseconds.
@@ -188,9 +188,38 @@ pub fn seconds_to_nanoseconds(value: i64) -> Option<i64> {
     value.checked_mul(i64::try_from(NANOS_PER_SECOND).unwrap())
 }
 
-/// Wrapper for timerfd
+/// A source of monotonic time; real, or a controllable virtual clock for tests.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum Clock {
+    /// Real monotonic time via [`Instant::now`].
+    #[default]
+    Real,
+    /// A controllable virtual clock, that only advances via [`Clock::advance`].
+    #[cfg(any(test, feature = "test-utils"))]
+    Mock(MockClock),
+}
+
+impl Clock {
+    /// Returns the current time according to this clock.
+    pub fn now(&self) -> Instant {
+        match self {
+            Clock::Real => Instant::now(),
+            #[cfg(any(test, feature = "test-utils"))]
+            Clock::Mock(clock) => clock.now(),
+        }
+    }
+}
+
+/// Wrapper for a one-shot / interval timer.
+/// Either backed by a real Linux `timerfd`, or mocked for testing.
 #[derive(Debug)]
-pub struct TimerFd(File);
+pub enum TimerFd {
+    /// A real, kernel-backed `timerfd`.
+    Real(File),
+    /// A deterministic, test-only timer driven by a [`MockClock`].
+    #[cfg(any(test, feature = "test-utils"))]
+    Mock(MockTimer),
+}
 
 #[allow(clippy::new_without_default)]
 impl TimerFd {
@@ -209,12 +238,23 @@ impl TimerFd {
             std::io::Error::last_os_error()
         );
         // SAFETY: we just created valid fd
-        TimerFd(unsafe { File::from_raw_fd(fd) })
+        TimerFd::Real(unsafe { File::from_raw_fd(fd) })
+    }
+
+    /// Creates a deterministic timer registered on `clock`.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn new_mocked(clock: &MockClock) -> Self {
+        TimerFd::Mock(MockTimer::new(clock))
     }
 
     /// Arm the timer to be triggered after `duration` and then
     /// at optional `interval`
     pub fn arm(&mut self, duration: Duration, interval: Option<Duration>) {
+        let file = match self {
+            TimerFd::Real(file) => file,
+            #[cfg(any(test, feature = "test-utils"))]
+            TimerFd::Mock(mock) => return mock.arm(duration, interval),
+        };
         #[allow(clippy::cast_possible_wrap)]
         let spec = libc::itimerspec {
             it_value: libc::timespec {
@@ -234,7 +274,7 @@ impl TimerFd {
             },
         };
         // SAFETY: Safe because this doesn't modify any memory and we check the return value.
-        let ret = unsafe { libc::timerfd_settime(self.as_raw_fd(), 0, &spec, ptr::null_mut()) };
+        let ret = unsafe { libc::timerfd_settime(file.as_raw_fd(), 0, &spec, ptr::null_mut()) };
         assert!(
             0 <= ret,
             "TimerFd arm failed: {:#}",
@@ -242,11 +282,18 @@ impl TimerFd {
         );
     }
 
-    /// Read the value from the timerfd. Since it is always created with NONBLOCK flag,
-    /// this function does not block.
+    /// Read the value from the timer. Since a real timer is always created with the NONBLOCK
+    /// flag, this function does not block and returns `0` if the timer has not fired. For a mock
+    /// timer it returns the number of expirations that have occurred (per the virtual clock)
+    /// since the previous read.
     pub fn read(&mut self) -> u64 {
+        let file = match self {
+            TimerFd::Real(file) => file,
+            #[cfg(any(test, feature = "test-utils"))]
+            TimerFd::Mock(mock) => return mock.read(),
+        };
         let mut buf = [0u8; size_of::<u64>()];
-        match self.0.read(buf.as_mut_slice()) {
+        match file.read(buf.as_mut_slice()) {
             Ok(_) => u64::from_ne_bytes(buf),
             Err(inner) if inner.kind() == ErrorKind::WouldBlock => 0,
             Err(err) => panic!("TimerFd read failed: {err:#}"),
@@ -255,10 +302,15 @@ impl TimerFd {
 
     /// Tell if the timer is currently armed.
     pub fn is_armed(&self) -> bool {
+        let file = match self {
+            TimerFd::Real(file) => file,
+            #[cfg(any(test, feature = "test-utils"))]
+            TimerFd::Mock(mock) => return mock.is_armed(),
+        };
         // SAFETY: Zero init of a PDO type.
         let mut spec: libc::itimerspec = unsafe { std::mem::zeroed() };
         // SAFETY: Safe because timerfd_gettime is trusted to only modify `spec`.
-        let ret = unsafe { libc::timerfd_gettime(self.as_raw_fd(), &mut spec) };
+        let ret = unsafe { libc::timerfd_gettime(file.as_raw_fd(), &mut spec) };
         assert!(
             0 <= ret,
             "TimerFd arm failed: {:#}",
@@ -270,9 +322,151 @@ impl TimerFd {
 
 impl AsRawFd for TimerFd {
     fn as_raw_fd(&self) -> RawFd {
-        self.0.as_raw_fd()
+        match self {
+            TimerFd::Real(file) => file.as_raw_fd(),
+            #[cfg(any(test, feature = "test-utils"))]
+            TimerFd::Mock(_) => panic!("Mocked timer doesn't support fd"),
+        }
     }
 }
+
+/// Test-only mock clock and timer, used to make time-based unit tests deterministic.
+///
+/// Gated behind `#[cfg(any(test, feature = "test-utils"))]` at the module level so the individual
+/// items don't each need the attribute. Re-exported from the parent so callers keep using
+/// [`MockClock`]/[`MockTimer`] directly.
+#[cfg(any(test, feature = "test-utils"))]
+mod mock {
+    use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
+
+    /// A controllable virtual clock for tests. Starts at the current real time, but only moves
+    /// forward via [`MockClock::advance`]. Cheap to [`Clone`]; all clones share the same
+    /// underlying time, so multiple consumers advance together.
+    #[derive(Debug, Clone)]
+    pub struct MockClock {
+        base: Instant,
+        elapsed: Arc<Mutex<Duration>>,
+    }
+
+    #[allow(clippy::new_without_default)]
+    impl MockClock {
+        /// Creates a new virtual clock with zero elapsed time.
+        pub fn new() -> Self {
+            MockClock {
+                base: Instant::now(),
+                elapsed: Arc::new(Mutex::new(Duration::ZERO)),
+            }
+        }
+
+        /// Returns the total virtual time elapsed since creation.
+        pub fn elapsed(&self) -> Duration {
+            *self.elapsed.lock().unwrap()
+        }
+
+        /// Advances the clock (and every clone of it) forward by `duration`.
+        pub fn advance(&self, duration: Duration) {
+            let mut clock_data = self.elapsed.lock().unwrap();
+            *clock_data = clock_data.saturating_add(duration)
+        }
+
+        /// Returns the current virtual time as an [`Instant`] (creation time plus elapsed).
+        pub fn now(&self) -> Instant {
+            self.base + self.elapsed()
+        }
+    }
+
+    impl PartialEq for MockClock {
+        fn eq(&self, other: &Self) -> bool {
+            self.base.eq(&other.base) && Arc::ptr_eq(&self.elapsed, &other.elapsed)
+        }
+    }
+
+    impl Eq for MockClock {}
+
+    /// The deterministic, virtual-clock timer behind [`TimerFd::Mock`](super::TimerFd::Mock)
+    ///
+    /// It holds no OS resources: expiry is tracked purely against its shared [`MockClock`], so
+    /// "firing" happens when the clock is advanced past the armed expiry rather than via the
+    /// kernel. Consequently, it has no file descriptor
+    /// ([`TimerFd::as_raw_fd`](super::TimerFd::as_raw_fd) panics).
+    #[derive(Debug)]
+    pub struct MockTimer {
+        clock: MockClock,
+        // Elapsed virtual time at which the timer first fires; `None` if disarmed.
+        expiry: Option<Duration>,
+        // Periodic re-arm interval. `None` (or a zero interval) means the timer is one-shot.
+        interval: Option<Duration>,
+        // Number of expirations already reported by `read`.
+        fired: u64,
+    }
+
+    impl MockTimer {
+        pub(super) fn new(clock: &MockClock) -> Self {
+            MockTimer {
+                clock: clock.clone(),
+                expiry: None,
+                interval: None,
+                fired: 0,
+            }
+        }
+
+        pub(super) fn arm(&mut self, duration: Duration, interval: Option<Duration>) {
+            // A zero `it_value` disarms a real `timerfd` (regardless of the interval) and discards
+            // any pending expirations, so mirror that here instead of firing immediately.
+            if duration.is_zero() {
+                self.expiry = None;
+                self.interval = None;
+                self.fired = 0;
+                return;
+            }
+            let elapsed = self.clock.elapsed();
+            self.expiry = Some(elapsed.saturating_add(duration));
+            self.interval = interval.filter(|i| !i.is_zero());
+            self.fired = 0;
+        }
+
+        pub(super) fn is_armed(&self) -> bool {
+            match self.expiry {
+                None => false,
+                // A one-shot timer stops being armed once it has fired; a periodic one stays armed.
+                Some(expiry) => match self.interval {
+                    None => self.clock.elapsed() < expiry,
+                    Some(_) => true,
+                },
+            }
+        }
+
+        /// Returns the number of expirations that have occurred (per the virtual clock) since the
+        /// previous read, consuming them — mirroring the non-blocking read of a real `timerfd`.
+        pub(super) fn read(&mut self) -> u64 {
+            let Some(expiry) = self.expiry else {
+                return 0;
+            };
+            let elapsed = self.clock.elapsed();
+            if elapsed < expiry {
+                return 0;
+            }
+            // Total expirations up to `elapsed`.
+            let total = match self.interval {
+                // One-shot: it has fired exactly once.
+                None => 1,
+                // Periodic: the initial expiration plus one per full interval elapsed since.
+                Some(interval) => {
+                    let ticks = 1 + (elapsed - expiry).as_nanos() / interval.as_nanos();
+                    u64::try_from(ticks).unwrap_or(u64::MAX)
+                }
+            };
+            let new = total - self.fired;
+            // Only report expirations not yet consumed by a previous read.
+            self.fired = total;
+            new
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+pub use mock::{MockClock, MockTimer};
 
 #[cfg(test)]
 mod tests {
@@ -342,5 +536,98 @@ mod tests {
         );
 
         assert!(seconds_to_nanoseconds(9_223_372_037).is_none());
+    }
+
+    #[test]
+    fn test_mock_timer_fd_one_shot() {
+        let clock = MockClock::new();
+        let mut timer = TimerFd::new_mocked(&clock);
+
+        // A fresh timer is disarmed and has no pending expirations.
+        assert!(!timer.is_armed());
+        assert_eq!(timer.read(), 0);
+
+        timer.arm(Duration::from_millis(100), None);
+        assert!(timer.is_armed());
+
+        // Advancing short of the expiry does nothing.
+        clock.advance(Duration::from_millis(50));
+        assert!(timer.is_armed());
+        assert_eq!(timer.read(), 0);
+
+        // Crossing the expiry fires exactly once and disarms the one-shot timer.
+        clock.advance(Duration::from_millis(50));
+        assert!(!timer.is_armed());
+        assert_eq!(timer.read(), 1);
+        // The expiration is consumed by the read.
+        assert_eq!(timer.read(), 0);
+    }
+
+    #[test]
+    fn test_mock_timer_fd_periodic() {
+        let clock = MockClock::new();
+        let mut timer = TimerFd::new_mocked(&clock);
+        timer.arm(Duration::from_millis(100), Some(Duration::from_millis(50)));
+
+        // Jumping across three interval boundaries accumulates three expirations, and the
+        // periodic timer stays armed.
+        clock.advance(Duration::from_millis(200));
+        assert!(timer.is_armed());
+        assert_eq!(timer.read(), 3);
+        assert_eq!(timer.read(), 0);
+
+        // The next boundary is at 250ms.
+        clock.advance(Duration::from_millis(50));
+        assert_eq!(timer.read(), 1);
+        assert_eq!(timer.read(), 0);
+
+        // Jumping two intervals
+        clock.advance(Duration::from_millis(100));
+        assert_eq!(timer.read(), 2);
+        assert_eq!(timer.read(), 0);
+    }
+
+    #[test]
+    fn test_mock_timer_fd_zero_interval_is_one_shot() {
+        let clock = MockClock::new();
+        let mut timer = TimerFd::new_mocked(&clock);
+        // A zero interval must behave as one-shot, matching `timerfd_settime` semantics.
+        timer.arm(Duration::from_millis(100), Some(Duration::ZERO));
+
+        clock.advance(Duration::from_millis(500));
+        assert!(!timer.is_armed());
+        assert_eq!(timer.read(), 1);
+        assert_eq!(timer.read(), 0);
+    }
+
+    #[test]
+    fn test_mock_timer_fd_zero_duration_disarms() {
+        let clock = MockClock::new();
+        let mut timer = TimerFd::new_mocked(&clock);
+
+        // Arming with a zero duration must disarm the timer and discard pending expirations,
+        // matching `timerfd_settime` with `it_value == 0` (this is how the codebase stops a
+        // timer, e.g. balloon `_reset`).
+        timer.arm(Duration::ZERO, None);
+        assert!(!timer.is_armed());
+        clock.advance(Duration::from_millis(500));
+        assert!(!timer.is_armed());
+        assert_eq!(timer.read(), 0);
+
+        // Disarming an already-armed timer clears its pending expirations.
+        timer.arm(Duration::from_millis(100), None);
+        clock.advance(Duration::from_millis(50));
+        assert!(timer.is_armed());
+        timer.arm(Duration::ZERO, None);
+        assert!(!timer.is_armed());
+        clock.advance(Duration::from_millis(500));
+        assert_eq!(timer.read(), 0);
+
+        // A zero duration disarms regardless of the interval.
+        timer.arm(Duration::from_millis(100), Some(Duration::from_millis(50)));
+        timer.arm(Duration::ZERO, Some(Duration::from_millis(50)));
+        assert!(!timer.is_armed());
+        clock.advance(Duration::from_millis(500));
+        assert_eq!(timer.read(), 0);
     }
 }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -67,6 +67,7 @@ criterion = { version = "0.8.2", default-features = false }
 device_tree = "1.1.0"
 itertools = "0.15.0"
 proptest = { version = "1.11.0", default-features = false, features = ["std"] }
+utils = { path = "../utils", features = ["test-utils"] }
 
 [[bench]]
 name = "cpu_templates"

--- a/src/vmm/src/devices/virtio/block/virtio/device.rs
+++ b/src/vmm/src/devices/virtio/block/virtio/device.rs
@@ -889,6 +889,7 @@ mod tests {
     use crate::devices::virtio::test_utils::{VirtQueue, default_interrupt, default_mem};
     use crate::rate_limiter::TokenType;
     use crate::vstate::memory::{Address, Bytes, GuestAddress};
+    use utils::time::MockClock;
 
     #[test]
     fn test_calculate_blk_size_and_topology() {
@@ -2006,7 +2007,8 @@ mod tests {
 
             // Create bandwidth rate limiter that allows only 5120 bytes/s with bucket size of 8
             // bytes.
-            let mut rl = RateLimiter::new(512, 0, 100, 0, 0, 0);
+            let clock = MockClock::new();
+            let mut rl = RateLimiter::new_mocked(512, 0, 100, 0, 0, 0, &clock);
             // Use up the budget.
             assert!(rl.consume(512, TokenType::Bytes));
 
@@ -2034,9 +2036,8 @@ mod tests {
                 assert_eq!(vq.used.idx.get(), 0);
             }
 
-            // Wait for 100ms to give the rate-limiter timer a chance to replenish.
-            // Wait for an extra 50ms to make sure the timerfd event makes its way from the kernel.
-            thread::sleep(Duration::from_millis(150));
+            // Advance the shared virtual clock past the refill timer (100ms).
+            clock.advance(Duration::from_millis(100));
 
             // Following write procedure should succeed because bandwidth should now be available.
             {
@@ -2075,7 +2076,8 @@ mod tests {
             let status_addr = GuestAddress(vq.dtable[2].addr.get());
 
             // Create ops rate limiter that allows only 10 ops/s with bucket size of 1 ops.
-            let mut rl = RateLimiter::new(0, 0, 0, 1, 0, 100);
+            let clock = MockClock::new();
+            let mut rl = RateLimiter::new_mocked(0, 0, 0, 1, 0, 100, &clock);
             // Use up the budget.
             assert!(rl.consume(1, TokenType::Ops));
 
@@ -2118,9 +2120,8 @@ mod tests {
                 assert_eq!(vq.used.idx.get(), 0);
             }
 
-            // Wait for 100ms to give the rate-limiter timer a chance to replenish.
-            // Wait for an extra 50ms to make sure the timerfd event makes its way from the kernel.
-            thread::sleep(Duration::from_millis(150));
+            // Advance the shared virtual clock past the refill timer (100ms).
+            clock.advance(Duration::from_millis(100));
 
             // Following write procedure should succeed because ops budget should now be available.
             {

--- a/src/vmm/src/devices/virtio/net/device.rs
+++ b/src/vmm/src/devices/virtio/net/device.rs
@@ -1115,11 +1115,11 @@ impl VirtioDevice for Net {
 #[macro_use]
 #[allow(clippy::cast_possible_truncation)]
 pub mod tests {
+    use std::mem;
     use std::net::Ipv4Addr;
     use std::os::fd::AsRawFd;
     use std::str::FromStr;
     use std::time::Duration;
-    use std::{mem, thread};
 
     use vm_memory::{GuestAddress, GuestMemoryBackend};
 
@@ -1146,6 +1146,7 @@ pub mod tests {
     use crate::test_utils::single_region_mem;
     use crate::utils::net::mac::{MAC_ADDR_LEN, MacAddr};
     use crate::vstate::memory::Address;
+    use utils::time::MockClock;
 
     impl Net {
         pub fn finish_frame(&mut self) {
@@ -2250,7 +2251,8 @@ pub mod tests {
         // Test TX bandwidth rate limiting
         {
             // create bandwidth rate limiter that allows 40960 bytes/s with bucket size 4096 bytes
-            let mut rl = RateLimiter::new(0x1000, 0, 100, 0, 0, 0);
+            let tx_clock = MockClock::new();
+            let mut rl = RateLimiter::new_mocked(0x1000, 0, 100, 0, 0, 0, &tx_clock);
             // use up the budget
             assert!(rl.consume(0x1000, TokenType::Bytes));
 
@@ -2280,9 +2282,8 @@ pub mod tests {
                 assert_eq!(th.net().metrics.tx_rate_limiter_throttled.count(), 2);
             }
 
-            // wait for 100ms to give the rate-limiter timer a chance to replenish
-            // wait for an extra 100ms to make sure the timerfd event makes its way from the kernel
-            thread::sleep(Duration::from_millis(200));
+            // Advance the shared virtual clock past the refill timer (100ms).
+            tx_clock.advance(Duration::from_millis(100));
 
             // following TX procedure should succeed because bandwidth should now be available
             {
@@ -2299,7 +2300,7 @@ pub mod tests {
                 assert_eq!(th.txq.used.idx.get(), 1);
             }
 
-            thread::sleep(Duration::from_millis(200));
+            tx_clock.advance(Duration::from_millis(100));
 
             // following TX procedure should succeed to handle the second frame as well
             {
@@ -2319,7 +2320,8 @@ pub mod tests {
         // Test RX bandwidth rate limiting
         {
             // create bandwidth rate limiter that allows 2000 bytes/s with bucket size 1000 bytes
-            let mut rl = RateLimiter::new(1000, 0, 1000, 0, 0, 0);
+            let rx_clock = MockClock::new();
+            let mut rl = RateLimiter::new_mocked(1000, 0, 1000, 0, 0, 0, &rx_clock);
 
             // set up RX
             assert!(th.net().rx_buffer.used_descriptors == 0);
@@ -2331,8 +2333,7 @@ pub mod tests {
 
             let mut frame = inject_tap_tx_frame(&th.net(), 1000);
 
-            // use up the budget (do it after injecting the tx frame, as socket communication is
-            // slow enough that the ratelimiter could replenish in the meantime).
+            // use up the budget
             assert!(rl.consume(1000, TokenType::Bytes));
 
             // set this rx rate limiter to be used
@@ -2365,9 +2366,9 @@ pub mod tests {
                 assert_eq!(th.net().metrics.rx_rate_limiter_throttled.count(), 2);
             }
 
-            // wait for 1000ms to give the rate-limiter timer a chance to replenish
-            // wait for an extra 1000ms to make sure the timerfd event makes its way from the kernel
-            thread::sleep(Duration::from_millis(2000));
+            // Advance the shared virtual clock by the full refill time (1000ms), replenishing the
+            // bucket and firing the limiter's timer — deterministic, no sleeping.
+            rx_clock.advance(Duration::from_millis(1000));
 
             // following RX procedure should succeed because bandwidth should now be available
             {
@@ -2404,7 +2405,8 @@ pub mod tests {
         // Test TX ops rate limiting
         {
             // create ops rate limiter that allows 10 ops/s with bucket size 1 ops
-            let mut rl = RateLimiter::new(0, 0, 0, 1, 0, 100);
+            let tx_clock = MockClock::new();
+            let mut rl = RateLimiter::new_mocked(0, 0, 0, 1, 0, 100, &tx_clock);
             // use up the budget
             assert!(rl.consume(1, TokenType::Ops));
 
@@ -2428,9 +2430,8 @@ pub mod tests {
                 assert_eq!(th.txq.used.idx.get(), 0);
             }
 
-            // wait for 100ms to give the rate-limiter timer a chance to replenish
-            // wait for an extra 100ms to make sure the timerfd event makes its way from the kernel
-            thread::sleep(Duration::from_millis(200));
+            // Advance the shared virtual clock past the refill timer (100ms).
+            tx_clock.advance(Duration::from_millis(100));
 
             // following TX procedure should succeed because ops should now be available
             {
@@ -2450,7 +2451,8 @@ pub mod tests {
         // Test RX ops rate limiting
         {
             // create ops rate limiter that allows 2 ops/s with bucket size 1 ops
-            let mut rl = RateLimiter::new(0, 0, 0, 1, 0, 1000);
+            let rx_clock = MockClock::new();
+            let mut rl = RateLimiter::new_mocked(0, 0, 0, 1, 0, 1000, &rx_clock);
 
             // set up RX
             assert!(th.net().rx_buffer.used_descriptors == 0);
@@ -2501,9 +2503,8 @@ pub mod tests {
                 assert_eq!(th.rxq.used.idx.get(), 0);
             }
 
-            // wait for 1000ms to give the rate-limiter timer a chance to replenish
-            // wait for an extra 1000ms to make sure the timerfd event makes its way from the kernel
-            thread::sleep(Duration::from_millis(2000));
+            // Advance the shared virtual clock by the full refill time (1000ms).
+            rx_clock.advance(Duration::from_millis(1000));
 
             // following RX procedure should succeed because ops should now be available
             {

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -5,7 +5,9 @@ use std::fmt;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::time::{Duration, Instant};
 
-use utils::time::TimerFd;
+#[cfg(test)]
+use utils::time::MockClock;
+use utils::time::{Clock, TimerFd};
 
 pub mod persist;
 
@@ -70,6 +72,9 @@ pub struct TokenBucket {
     // Last time this token bucket saw activity.
     last_update: Instant,
 
+    // Clock source used to measure elapsed time for replenishment.
+    clock: Clock,
+
     // Fields used for pre-processing optimizations.
     processed_capacity: u64,
     processed_refill_time: u64,
@@ -85,6 +90,33 @@ impl TokenBucket {
     ///
     /// If the `size` or the `complete refill time` are zero, then `None` is returned.
     pub fn new(size: u64, one_time_burst: u64, complete_refill_time_ms: u64) -> Option<Self> {
+        Self::new_with_clock(size, one_time_burst, complete_refill_time_ms, Clock::Real)
+    }
+
+    /// Test-only: like [`TokenBucket::new`], but the bucket measures elapsed time for
+    /// replenishment against the given deterministic mock `clock` instead of the real monotonic
+    /// clock, making token replenishment controllable from tests.
+    #[cfg(test)]
+    pub fn new_mocked(
+        size: u64,
+        one_time_burst: u64,
+        complete_refill_time_ms: u64,
+        clock: &MockClock,
+    ) -> Option<Self> {
+        Self::new_with_clock(
+            size,
+            one_time_burst,
+            complete_refill_time_ms,
+            Clock::Mock(clock.clone()),
+        )
+    }
+    /// Creates a `TokenBucket` (wrapped in an `Option`) backed by the given `clock`.
+    fn new_with_clock(
+        size: u64,
+        one_time_burst: u64,
+        complete_refill_time_ms: u64,
+        clock: Clock,
+    ) -> Option<Self> {
         // If either token bucket capacity or refill time is 0, disable limiting.
         if size == 0 || complete_refill_time_ms == 0 {
             return None;
@@ -110,8 +142,9 @@ impl TokenBucket {
             refill_time: complete_refill_time_ms,
             // Start off full.
             budget: size,
-            // Last updated is now.
-            last_update: Instant::now(),
+            // Last updated is now, according to the provided clock.
+            last_update: clock.now(),
+            clock,
             processed_capacity,
             processed_refill_time,
         })
@@ -120,8 +153,8 @@ impl TokenBucket {
     // Replenishes token bucket based on elapsed time. Should only be called internally by `Self`.
     #[allow(clippy::cast_possible_truncation)]
     fn auto_replenish(&mut self) {
-        // Compute time passed since last refill/update.
-        let now = Instant::now();
+        // Compute time passed since last refill/update, according to the bucket's clock.
+        let now = self.clock.now();
         let time_delta = (now - self.last_update).as_nanos();
 
         if time_delta >= u128::from(self.refill_time * NANOSEC_IN_ONE_MILLISEC) {
@@ -178,7 +211,7 @@ impl TokenBucket {
             // We still have burst budget for *all* tokens requests.
             if self.one_time_burst >= tokens {
                 self.one_time_burst -= tokens;
-                self.last_update = Instant::now();
+                self.last_update = self.clock.now();
                 // No need to continue to the refill process, we still have burst budget to consume
                 // from.
                 return BucketReduction::Success;
@@ -298,7 +331,9 @@ pub enum BucketUpdate {
 pub struct RateLimiter {
     bandwidth: Option<TokenBucket>,
     ops: Option<TokenBucket>,
-
+    // We need a timer_fd, even if our current config effectively disables rate limiting,
+    // because `Self::update_buckets()` might re-enable it later, and we might be
+    // seccomp-blocked from creating the timer_fd at that time.
     timer_fd: TimerFd,
     // Internal flag that quickly determines timer state.
     timer_active: bool,
@@ -358,15 +393,46 @@ impl RateLimiter {
             ops_complete_refill_time_ms,
         );
 
-        // We'll need a timer_fd, even if our current config effectively disables rate limiting,
-        // because `Self::update_buckets()` might re-enable it later, and we might be
-        // seccomp-blocked from creating the timer_fd at that time.
-        let timer_fd = TimerFd::new();
+        RateLimiter {
+            bandwidth: bytes_token_bucket,
+            ops: ops_token_bucket,
+            timer_fd: TimerFd::new(),
+            timer_active: false,
+        }
+    }
+
+    /// Test-only: like [`RateLimiter::new`], but the buckets and timer are driven by the given
+    /// deterministic mock `clock`. Advancing `clock` (in place of `thread::sleep`) moves the
+    /// buckets' replenishment and the timer's expiry in lock step, keeping timer-driven tests
+    /// fast and reproducible.
+    #[cfg(test)]
+    pub(crate) fn new_mocked(
+        bytes_total_capacity: u64,
+        bytes_one_time_burst: u64,
+        bytes_complete_refill_time_ms: u64,
+        ops_total_capacity: u64,
+        ops_one_time_burst: u64,
+        ops_complete_refill_time_ms: u64,
+        clock: &MockClock,
+    ) -> Self {
+        let bytes_token_bucket = TokenBucket::new_mocked(
+            bytes_total_capacity,
+            bytes_one_time_burst,
+            bytes_complete_refill_time_ms,
+            clock,
+        );
+
+        let ops_token_bucket = TokenBucket::new_mocked(
+            ops_total_capacity,
+            ops_one_time_burst,
+            ops_complete_refill_time_ms,
+            clock,
+        );
 
         RateLimiter {
             bandwidth: bytes_token_bucket,
             ops: ops_token_bucket,
-            timer_fd,
+            timer_fd: TimerFd::new_mocked(clock),
             timer_active: false,
         }
     }
@@ -758,23 +824,15 @@ mod verification {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::thread;
     use std::time::Duration;
 
     use super::*;
-
-    // Define custom refill interval to be a bit bigger. This will help
-    // in tests which wait for a limiter refill in 2 stages. This will make it so
-    // second wait will always result in the limiter being refilled. Otherwise
-    // there is a chance for a race condition between limiter refilling and limiter
-    // checking.
-    const TEST_REFILL_TIMER_DURATION: Duration = Duration::from_millis(110);
 
     impl TokenBucket {
         // Resets the token bucket: budget set to max capacity and last-updated set to now.
         fn reset(&mut self) {
             self.budget = self.size;
-            self.last_update = Instant::now();
+            self.last_update = self.clock.now();
         }
 
         fn get_last_update(&self) -> &Instant {
@@ -812,33 +870,33 @@ pub(crate) mod tests {
         // These values will give 1 token every 100 milliseconds
         const SIZE: u64 = 10;
         const TIME: u64 = 1000;
-        let mut tb = TokenBucket::new(SIZE, 0, TIME).unwrap();
+        let clock = MockClock::new();
+        let mut tb = TokenBucket::new_mocked(SIZE, 0, TIME, &clock).unwrap();
         tb.reduce(SIZE);
         assert_eq!(tb.budget(), 0);
 
         // Auto-replenishing after 10 milliseconds should not yield any tokens
-        thread::sleep(Duration::from_millis(10));
+        clock.advance(Duration::from_millis(10));
         tb.auto_replenish();
         assert_eq!(tb.budget(), 0);
 
         // Neither after 20.
-        thread::sleep(Duration::from_millis(10));
+        clock.advance(Duration::from_millis(10));
         tb.auto_replenish();
         assert_eq!(tb.budget(), 0);
 
         // We should get 1 token after 100 millis
-        thread::sleep(Duration::from_millis(80));
+        clock.advance(Duration::from_millis(80));
         tb.auto_replenish();
         assert_eq!(tb.budget(), 1);
 
         // So, 5 after 500 millis
-        thread::sleep(Duration::from_millis(400));
+        clock.advance(Duration::from_millis(400));
         tb.auto_replenish();
         assert_eq!(tb.budget(), 5);
 
         // And be fully replenished after 1 second.
-        // Wait more here to make sure we do not overshoot
-        thread::sleep(Duration::from_millis(1000));
+        clock.advance(Duration::from_millis(500));
         tb.auto_replenish();
         assert_eq!(tb.budget(), 10);
     }
@@ -847,29 +905,28 @@ pub(crate) mod tests {
     fn test_token_bucket_auto_replenish_two() {
         const SIZE: u64 = 1000;
         const TIME: u64 = 1000;
-        let time = Duration::from_millis(TIME);
 
-        let mut tb = TokenBucket::new(SIZE, 0, TIME).unwrap();
+        let clock = MockClock::new();
+        let mut tb = TokenBucket::new_mocked(SIZE, 0, TIME, &clock).unwrap();
         tb.reduce(SIZE);
         assert_eq!(tb.budget(), 0);
 
-        let now = Instant::now();
-        while now.elapsed() < time {
+        // Replenish in many small steps; after a full second the bucket is back to capacity.
+        for i in 0..TIME {
+            assert_eq!(tb.budget(), i);
+            clock.advance(Duration::from_millis(1));
             tb.auto_replenish();
         }
-        tb.auto_replenish();
         assert_eq!(tb.budget(), SIZE);
     }
 
     #[test]
     fn test_token_bucket_create() {
-        let before = Instant::now();
-        let tb = TokenBucket::new(1000, 0, 1000).unwrap();
+        let clock = MockClock::new();
+        let tb = TokenBucket::new_mocked(1000, 0, 1000, &clock).unwrap();
         assert_eq!(tb.capacity(), 1000);
         assert_eq!(tb.budget(), 1000);
-        assert!(*tb.get_last_update() >= before);
-        let after = Instant::now();
-        assert!(*tb.get_last_update() <= after);
+        assert_eq!(*tb.get_last_update(), clock.now());
         assert_eq!(tb.get_processed_capacity(), 1);
         assert_eq!(tb.get_processed_refill_time(), 1_000_000);
 
@@ -900,33 +957,32 @@ pub(crate) mod tests {
         // allowing rate of 1 token/ms.
         let capacity = 1000;
         let refill_ms = 1000;
-        let mut tb = TokenBucket::new(capacity, 0, refill_ms).unwrap();
+        let clock = MockClock::new();
+        let mut tb = TokenBucket::new_mocked(capacity, 0, refill_ms, &clock).unwrap();
 
         assert_eq!(tb.reduce(123), BucketReduction::Success);
         assert_eq!(tb.budget(), capacity - 123);
         assert_eq!(tb.reduce(capacity), BucketReduction::Failure);
 
         // token bucket with capacity 1000 and refill time of 1000 milliseconds
-        let mut tb = TokenBucket::new(1000, 1100, 1000).unwrap();
-        // safely assuming the thread can run these 3 commands in less than 500ms
+        let clock = MockClock::new();
+        let mut tb = TokenBucket::new_mocked(1000, 1100, 1000, &clock).unwrap();
         assert_eq!(tb.reduce(1000), BucketReduction::Success);
         assert_eq!(tb.one_time_burst(), 100);
         assert_eq!(tb.reduce(500), BucketReduction::Success);
         assert_eq!(tb.one_time_burst(), 0);
         assert_eq!(tb.reduce(500), BucketReduction::Success);
         assert_eq!(tb.reduce(500), BucketReduction::Failure);
-        thread::sleep(Duration::from_millis(500));
+        clock.advance(Duration::from_millis(500));
         assert_eq!(tb.reduce(500), BucketReduction::Success);
-        thread::sleep(Duration::from_millis(1000));
+        clock.advance(Duration::from_millis(1000));
         assert_eq!(tb.reduce(2500), BucketReduction::OverConsumption(1.5));
 
-        let before = Instant::now();
         tb.reset();
         assert_eq!(tb.capacity(), 1000);
         assert_eq!(tb.budget(), 1000);
-        assert!(*tb.get_last_update() >= before);
-        let after = Instant::now();
-        assert!(*tb.get_last_update() <= after);
+        // `reset` sets `last_update` to the current time of the bucket's clock.
+        assert_eq!(*tb.get_last_update(), clock.now());
     }
 
     #[test]
@@ -988,12 +1044,11 @@ pub(crate) mod tests {
     #[test]
     fn test_rate_limiter_bandwidth() {
         // rate limiter with limit of 1000 bytes/s
-        let mut l = RateLimiter::new(1000, 0, 1000, 0, 0, 0);
+        let clock = MockClock::new();
+        let mut l = RateLimiter::new_mocked(1000, 0, 1000, 0, 0, 0, &clock);
 
         // limiter should not be blocked
         assert!(!l.is_blocked());
-        // raw FD for this disabled should be valid
-        assert!(l.as_raw_fd() > 0);
 
         // ops/s limiter should be disabled so consume(whatever) should work
         assert!(l.consume(u64::MAX, TokenType::Ops));
@@ -1004,13 +1059,13 @@ pub(crate) mod tests {
         assert!(!l.consume(100, TokenType::Bytes));
         // since consume failed, limiter should be blocked now
         assert!(l.is_blocked());
-        // wait half the timer period
-        thread::sleep(TEST_REFILL_TIMER_DURATION / 2);
+        // advance half the timer period
+        clock.advance(REFILL_TIMER_DURATION / 2);
         // limiter should still be blocked
         assert!(l.is_blocked());
-        // wait the other half of the timer period
-        thread::sleep(TEST_REFILL_TIMER_DURATION / 2);
-        // the timer_fd should have an event on it by now
+        // advance the other half of the timer period
+        clock.advance(REFILL_TIMER_DURATION / 2);
+        // the timer should have an event on it by now
         l.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!l.is_blocked());
@@ -1021,12 +1076,11 @@ pub(crate) mod tests {
     #[test]
     fn test_rate_limiter_ops() {
         // rate limiter with limit of 1000 ops/s
-        let mut l = RateLimiter::new(0, 0, 0, 1000, 0, 1000);
+        let clock = MockClock::new();
+        let mut l = RateLimiter::new_mocked(0, 0, 0, 1000, 0, 1000, &clock);
 
         // limiter should not be blocked
         assert!(!l.is_blocked());
-        // raw FD for this disabled should be valid
-        assert!(l.as_raw_fd() > 0);
 
         // bytes/s limiter should be disabled so consume(whatever) should work
         assert!(l.consume(u64::MAX, TokenType::Bytes));
@@ -1037,13 +1091,13 @@ pub(crate) mod tests {
         assert!(!l.consume(100, TokenType::Ops));
         // since consume failed, limiter should be blocked now
         assert!(l.is_blocked());
-        // wait half the timer period
-        thread::sleep(TEST_REFILL_TIMER_DURATION / 2);
+        // advance half the timer period
+        clock.advance(REFILL_TIMER_DURATION / 2);
         // limiter should still be blocked
         assert!(l.is_blocked());
-        // wait the other half of the timer period
-        thread::sleep(TEST_REFILL_TIMER_DURATION / 2);
-        // the timer_fd should have an event on it by now
+        // advance the other half of the timer period
+        clock.advance(REFILL_TIMER_DURATION / 2);
+        // the timer should have an event on it by now
         l.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!l.is_blocked());
@@ -1054,14 +1108,13 @@ pub(crate) mod tests {
     #[test]
     fn test_rate_limiter_full() {
         // rate limiter with limit of 1000 bytes/s and 1000 ops/s
-        let mut l = RateLimiter::new(1000, 0, 1000, 1000, 0, 1000);
+        let clock = MockClock::new();
+        let mut l = RateLimiter::new_mocked(1000, 0, 1000, 1000, 0, 1000, &clock);
 
         // limiter should not be blocked
         assert!(!l.is_blocked());
-        // raw FD for this disabled should be valid
-        assert!(l.as_raw_fd() > 0);
 
-        // do full 1000 bytes
+        // do full 1000 ops
         assert!(l.consume(1000, TokenType::Ops));
         // do full 1000 bytes
         assert!(l.consume(1000, TokenType::Bytes));
@@ -1071,13 +1124,13 @@ pub(crate) mod tests {
         assert!(!l.consume(100, TokenType::Bytes));
         // since consume failed, limiter should be blocked now
         assert!(l.is_blocked());
-        // wait half the timer period
-        thread::sleep(TEST_REFILL_TIMER_DURATION / 2);
+        // advance half the timer period
+        clock.advance(REFILL_TIMER_DURATION / 2);
         // limiter should still be blocked
         assert!(l.is_blocked());
-        // wait the other half of the timer period
-        thread::sleep(TEST_REFILL_TIMER_DURATION / 2);
-        // the timer_fd should have an event on it by now
+        // advance the other half of the timer period
+        clock.advance(REFILL_TIMER_DURATION / 2);
+        // the timer should have an event on it by now
         l.event_handler().unwrap();
         // limiter should now be unblocked
         assert!(!l.is_blocked());
@@ -1090,7 +1143,8 @@ pub(crate) mod tests {
     #[test]
     fn test_rate_limiter_overconsumption() {
         // initialize the rate limiter
-        let mut l = RateLimiter::new(1000, 0, 1000, 1000, 0, 1000);
+        let clock = MockClock::new();
+        let mut l = RateLimiter::new_mocked(1000, 0, 1000, 1000, 0, 1000, &clock);
         // try to consume 2.5x the bucket size
         // we are "borrowing" 1.5x the bucket size in tokens since
         // the bucket is full
@@ -1098,18 +1152,19 @@ pub(crate) mod tests {
 
         // check that even after a whole second passes, the rate limiter
         // is still blocked
-        thread::sleep(Duration::from_millis(1000));
+        clock.advance(Duration::from_millis(1000));
         l.event_handler().unwrap_err();
         assert!(l.is_blocked());
 
         // after 1.5x the replenish time has passed, the rate limiter
         // is available again
-        thread::sleep(Duration::from_millis(500));
+        clock.advance(Duration::from_millis(500));
         l.event_handler().unwrap();
         assert!(!l.is_blocked());
 
         // reset the rate limiter
-        let mut l = RateLimiter::new(1000, 0, 1000, 1000, 0, 1000);
+        let clock = MockClock::new();
+        let mut l = RateLimiter::new_mocked(1000, 0, 1000, 1000, 0, 1000, &clock);
         // try to consume 1.5x the bucket size
         // we are "borrowing" 1.5x the bucket size in tokens since
         // the bucket is full, should arm the timer to 0.5x replenish
@@ -1118,7 +1173,7 @@ pub(crate) mod tests {
 
         // check that after more than the minimum refill time,
         // the rate limiter is still blocked
-        thread::sleep(Duration::from_millis(200));
+        clock.advance(Duration::from_millis(200));
         l.event_handler().unwrap_err();
         assert!(l.is_blocked());
 
@@ -1131,14 +1186,14 @@ pub(crate) mod tests {
         // check that after the minimum refill time, the timer was not
         // overwritten and the rate limiter is still blocked from the
         // borrowing we performed earlier
-        thread::sleep(Duration::from_millis(100));
+        clock.advance(Duration::from_millis(100));
         l.event_handler().unwrap_err();
         assert!(l.is_blocked());
         assert!(!l.consume(100, TokenType::Bytes));
 
         // after waiting out the full duration, rate limiter should be
-        // availale again
-        thread::sleep(Duration::from_millis(200));
+        // available again
+        clock.advance(Duration::from_millis(200));
         l.event_handler().unwrap();
         assert!(!l.is_blocked());
         assert!(l.consume(100, TokenType::Bytes));


### PR DESCRIPTION
## Changes

This PR adds `MockClock` and `MockTimer`. A new variant of `TimerFd`, `TimerFd::Mock`, can be used on unit tests that do not need the underlying timer file-descriptor.

It allows for deterministic time-based tests by using `MockClock::advance` instead of sleeping.

The new components are used on the unit tests of `RateLimiter`, `TokenBucket`, VirtIO block and VirtIO net.

## Reason

The main reason is to reduce test flakiness.

Additionally, having deterministic tests allows for more precise tests (no need to add "safety margins around sleep), and faster test execution (there's no actual sleep involved).

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle --no-clippy` to verify that the PR
  passes the automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
