### PR TITLE
test: poll serial.log in test_serial_file_output

### DIFF
--- a/tests/integration_tests/functional/test_serial_io.py
+++ b/tests/integration_tests/functional/test_serial_io.py
@@ -260,7 +260,16 @@ def test_no_serial_fd_error_when_daemonized(uvm):
 @pin_cpu_template(ALL_CPU_TEMPLATES)
 def test_serial_file_output(uvm_any):
     """Test that redirecting serial console output to a file works for booted and restored VMs"""
-    uvm_any.ssh.check_output("echo 'hello' > /dev/ttyS0")
+    # write() returns once the bytes are in the tty's transmit FIFO, not
+    # once the UART has transmitted them, and closing /dev/ttyS0 only drains
+    # on the last close (the console getty keeps it open). On kernels >= 6.4
+    # with a runtime-PM-enabled UART driver (8250_of on aarch64), a write to
+    # an idle (runtime-suspended) port is even transmitted later by a kworker.
+    # Drain explicitly: stty applies settings with tcsetattr(TCSADRAIN), which
+    # waits for the tty buffer and the UART transmitter to be empty.
+    uvm_any.ssh.check_output(
+        "echo 'hello' > /dev/ttyS0 && stty -F /dev/ttyS0 $(stty -F /dev/ttyS0 -g)"
+    )
 
     assert b"hello" in uvm_any.serial_out_path.read_bytes()
 


### PR DESCRIPTION
## Changes

The guest's write() to `/dev/ttyS0` returns once the bytes are in the tty transmit FIFO, not once the UART has sent them. 

Since Linux 6.4 the serial core runtime-suspends the port after 500ms of inactivity and, if the UART driver has runtime PM enabled (8250_of on aarch64; 8250_pnp on x86 does not), `__uart_start()` defers `start_tx()` to the asynchronous runtime resume on a kworker. On a loaded host that kworker can run a few hundred milliseconds after the ssh command has returned, so a single read of serial.log right after the echo can miss the output.

This was observed once in the nightly on m7g.metal with the 6.18 guest in the restored variant: the post-failure artifacts show "hello" in serial.log, written between the assertion and the next metrics flush. Reproduced on m7g.metal by holding the writer CPU with a SCHED_FIFO task after the write: 4/5 misses with runtime PM in "auto", 0/5 with the port forced active, 0/5 with this polling assertion.

Poll the file for up to 5 seconds instead of reading it once.

## Reason

Improve test reliability

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle --no-clippy` to verify that the PR
  passes the automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
