### PR TITLE
vmm: Pass pci_enabled to VmResources::from_json() 

### DIFF
--- a/src/cpu-template-helper/src/utils/mod.rs
+++ b/src/cpu-template-helper/src/utils/mod.rs
@@ -127,7 +127,7 @@ pub fn build_microvm_from_config(
         app_name: "cpu-template-helper".to_string(),
     };
     let mut vm_resources =
-        VmResources::from_json(&config, &instance_info, HTTP_MAX_PAYLOAD_SIZE, None)
+        VmResources::from_json(&config, &instance_info, HTTP_MAX_PAYLOAD_SIZE, None, false)
             .map_err(UtilsError::CreateVmResources)?;
     if let Some(template) = template {
         vm_resources.set_custom_cpu_template(template);

--- a/src/firecracker/src/main.rs
+++ b/src/firecracker/src/main.rs
@@ -594,11 +594,15 @@ fn build_microvm_from_json(
     mmds_size_limit: usize,
     metadata_json: Option<&str>,
 ) -> Result<Arc<Mutex<vmm::Vmm>>, BuildFromJsonError> {
-    let mut vm_resources =
-        VmResources::from_json(&config_json, &instance_info, mmds_size_limit, metadata_json)
-            .map_err(BuildFromJsonError::ParseFromJson)?;
+    let mut vm_resources = VmResources::from_json(
+        &config_json,
+        &instance_info,
+        mmds_size_limit,
+        metadata_json,
+        pci_enabled,
+    )
+    .map_err(BuildFromJsonError::ParseFromJson)?;
     vm_resources.boot_timer = boot_timer_enabled;
-    vm_resources.pci_enabled = pci_enabled;
     let vmm = vmm::builder::build_and_boot_microvm(
         &instance_info,
         &vm_resources,

--- a/src/vmm/src/persist.rs
+++ b/src/vmm/src/persist.rs
@@ -433,6 +433,22 @@ pub fn restore_from_snapshot(
         .map_err(|_| MachineConfigError::InvalidVcpuCount)
         .map_err(BuildMicrovmFromSnapshotError::VmUpdateConfig)?;
 
+    // Due to questionable past API design decisions whether the restored VM
+    // uses PCI is decided by the snapshot and not by the --enable-pci flag of
+    // the process doing the restore. Set the option based on the snapshot
+    // state.
+    let pci_enabled = matches!(
+        microvm_state.device_states.virtio_state,
+        VirtioDevicesState::Pci(_)
+    );
+    if pci_enabled != vm_resources.pci_enabled {
+        warn!(
+            "The snapshot's PCI configuration does not match --enable-pci; \
+             following the snapshot configuration."
+        );
+    }
+    vm_resources.pci_enabled = pci_enabled;
+
     vm_resources
         .update_machine_config(&MachineConfigUpdate {
             vcpu_count: Some(vcpu_count),

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -158,6 +158,7 @@ impl VmResources {
         instance_info: &InstanceInfo,
         mmds_size_limit: usize,
         metadata_json: Option<&str>,
+        pci_enabled: bool,
     ) -> Result<Self, ResourcesError> {
         let vmm_config = serde_json::from_str::<VmmConfig>(config_json)?;
 
@@ -171,6 +172,7 @@ impl VmResources {
 
         let mut resources: Self = Self {
             mmds_size_limit,
+            pci_enabled,
             ..Default::default()
         };
         if let Some(machine_config) = vmm_config.machine_config {
@@ -686,9 +688,14 @@ mod tests {
         // these resources, it is considered an invalid json and the test will crash.
 
         // Invalid JSON string must yield a `serde_json` error.
-        let error =
-            VmResources::from_json(r#"}"#, &default_instance_info, HTTP_MAX_PAYLOAD_SIZE, None)
-                .unwrap_err();
+        let error = VmResources::from_json(
+            r#"}"#,
+            &default_instance_info,
+            HTTP_MAX_PAYLOAD_SIZE,
+            None,
+            false,
+        )
+        .unwrap_err();
         assert!(
             matches!(error, ResourcesError::InvalidJson(_)),
             "{:?}",
@@ -697,9 +704,14 @@ mod tests {
 
         // Valid JSON string without the configuration for kernel or rootfs
         // result in an invalid JSON error.
-        let error =
-            VmResources::from_json(r#"{}"#, &default_instance_info, HTTP_MAX_PAYLOAD_SIZE, None)
-                .unwrap_err();
+        let error = VmResources::from_json(
+            r#"{}"#,
+            &default_instance_info,
+            HTTP_MAX_PAYLOAD_SIZE,
+            None,
+            false,
+        )
+        .unwrap_err();
         assert!(
             matches!(error, ResourcesError::InvalidJson(_)),
             "{:?}",
@@ -730,6 +742,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap_err();
         assert!(
@@ -765,6 +778,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap_err();
         assert!(
@@ -807,6 +821,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap();
         #[cfg(target_arch = "aarch64")]
@@ -815,6 +830,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap_err();
 
@@ -847,6 +863,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap_err();
         assert!(
@@ -886,6 +903,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap_err();
         assert!(
@@ -925,6 +943,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap_err();
         assert!(
@@ -971,6 +990,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap_err();
 
@@ -1027,6 +1047,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap();
 
@@ -1085,6 +1106,7 @@ mod tests {
             &default_instance_info,
             1200,
             Some(r#"{"key": "value"}"#),
+            false,
         )
         .unwrap();
         let mut map = Map::new();
@@ -1128,6 +1150,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap_err();
         assert!(matches!(error, ResourcesError::File(_)), "{:?}", error);
@@ -1166,6 +1189,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap();
     }
@@ -1209,6 +1233,7 @@ mod tests {
             &default_instance_info,
             HTTP_MAX_PAYLOAD_SIZE,
             None,
+            false,
         )
         .unwrap();
         assert_eq!(
@@ -1278,6 +1303,7 @@ mod tests {
                     &InstanceInfo::default(),
                     HTTP_MAX_PAYLOAD_SIZE,
                     None,
+                    false,
                 )
                 .unwrap();
 
@@ -1293,6 +1319,7 @@ mod tests {
                     &InstanceInfo::default(),
                     HTTP_MAX_PAYLOAD_SIZE,
                     Some(r#"{"key": "value"}"#),
+                    false,
                 )
                 .unwrap();
 
@@ -1362,6 +1389,7 @@ mod tests {
                 &InstanceInfo::default(),
                 HTTP_MAX_PAYLOAD_SIZE,
                 None,
+                false,
             )
             .unwrap();
 
@@ -1430,6 +1458,7 @@ mod tests {
                 &InstanceInfo::default(),
                 HTTP_MAX_PAYLOAD_SIZE,
                 None,
+                false,
             )
             .unwrap();
 


### PR DESCRIPTION

    VmResources::from_json() applies the machine config while building the
    resources, but the caller only set pci_enabled afterwards. Any
    machine-config validation that depends on whether PCI is enabled (such
    as the upcoming pcie_hotplug_ports option) would therefore see it as
    disabled on the config-file path. Fix this by passing pci_enabled into
    from_json().

 
## License Acceptance

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license. For more information on following Developer
Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [ ] I have read and understand [CONTRIBUTING.md][3].
- [ ] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [ ] I have run `tools/devtool checkstyle --no-clippy` to verify that the PR
  passes the automated style checks.
- [ ] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [ ] I have updated any relevant documentation (both in code and in the docs)
  in the PR.
- [ ] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [ ] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [ ] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md
