### PR TITLE
fix(rate_limiter): arm timer for sub-millisecond overconsumption debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to
 
 ### Fixed
 
+- [#6211](https://github.com/firecracker-microvm/firecracker/pull/6211): Fixed
+  the rate limiter permanently throttling a device when a single request
+  exceeded the bucket size by less than one millisecond's worth of tokens. The
+  overconsumption debt was truncated to `0ms`, which disarmed the underlying
+  timerfd while the limiter stayed marked as blocked, so the timer never fired
+  and the device I/O hung until the microVM was restarted. The debt is now
+  computed in nanoseconds and rounded up.
+
 ## [1.17.0]
 
 ### Added

--- a/src/vmm/src/rate_limiter/mod.rs
+++ b/src/vmm/src/rate_limiter/mod.rs
@@ -482,9 +482,21 @@ impl RateLimiter {
                     // order to enforce the bandwidth limit we need to prevent
                     // further calls to the rate limiter for
                     // `ratio * refill_time` milliseconds.
-                    // The conversion should be safe because the ratio is positive.
+                    //
+                    // Compute the duration in nanoseconds instead of
+                    // milliseconds and round up. Truncating sub-millisecond
+                    // debts to zero would call `TimerFd::arm` with a zero
+                    // `Duration`, which disarms the underlying timerfd while
+                    // `timer_active` is still set. The limiter would then never
+                    // receive an event and stay blocked forever.
+                    //
+                    // The conversion is safe because the ratio is strictly
+                    // positive and `refill_time` is at least 1, so after
+                    // rounding up the duration is at least one nanosecond.
                     #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
-                    self.activate_timer(Duration::from_millis((ratio * refill_time as f64) as u64));
+                    let duration_ns =
+                        (ratio * refill_time as f64 * NANOSEC_IN_ONE_MILLISEC as f64).ceil() as u64;
+                    self.activate_timer(Duration::from_nanos(duration_ns));
                     true
                 }
             }
@@ -1197,6 +1209,30 @@ pub(crate) mod tests {
         l.event_handler().unwrap();
         assert!(!l.is_blocked());
         assert!(l.consume(100, TokenType::Bytes));
+    }
+
+    #[test]
+    fn test_rate_limiter_overconsumption_sub_millisecond() {
+        // Bucket of 1_000_000 bytes that refills completely in one second.
+        // Borrowing one single token beyond the bucket capacity must be
+        // replenished in `1/1_000_000 * 1000 ms = 0.001 ms`. The limiter has
+        // to arm a real (sub-millisecond) timer for that debt. If the duration
+        // is truncated to zero, the timerfd gets disarmed while `timer_active`
+        // stays set, and the limiter is wedged forever.
+        let clock = MockClock::new();
+        let mut l = RateLimiter::new_mocked(1_000_000, 0, 1000, 0, 0, 0, &clock);
+
+        // Consume one byte more than the full bucket, i.e. borrow 1 token.
+        assert!(l.consume(1_000_001, TokenType::Bytes));
+        assert!(l.is_blocked());
+
+        // The timer has to fire and unblock the limiter. With the buggy
+        // millisecond truncation the timer is disarmed, so `event_handler`
+        // returns `SpuriousRateLimiterEvent` and the assertions below fail.
+        clock.advance(Duration::from_millis(50));
+        l.event_handler().unwrap();
+        assert!(!l.is_blocked());
+        assert!(l.consume(1, TokenType::Bytes));
     }
 
     #[test]


### PR DESCRIPTION
## Changes

Compute the rate limiter's refill duration directly in nanoseconds using integer arithmetic and round up instead of truncating to milliseconds.

- Add `time_to_refill()` to calculate the refill duration using `u128` and `div_ceil()`.
- Reuse `time_to_refill()` in both `auto_replenish()` and `reduce()`.
- Store `BucketReduction::OverConsumption` as a `Duration` instead of `f64`.
- Add a regression test `test_rate_limiter_overconsumption_sub_millisecond` covering sub-millisecond overconsumption debt.

Closes #6212

## Reason

When a single request exceeds the bucket size, the rate limiter allows it and arms a timer so the device waits for `ratio * refill_time` before the next request. The wait was converted with millisecond truncation, so a debt below one millisecond was truncated to zero. `TimerFd::arm` with a zero duration then disarms the timerfd while `timer_active` remains set, leaving the limiter blocked and the device I/O starved forever.

The refill duration is now calculated directly in nanoseconds and rounded up. Since the overconsumed token count is positive, the resulting duration is at least one nanosecond, ensuring that the timer is armed.

Trigger condition: with a full bucket, a single request of D bytes against a bandwidth bucket of S bytes refilled every T ms can wedge the device when D > S and D - S < S / T. For example, `size=4095`, `refill_time=1`, and one 4096-byte request produces a debt of 0.000244 ms, which was previously truncated to 0 ms and disarmed the timerfd.

Testing: the regression test borrows one token from a 1,000,000-byte bucket refilled every 1000 ms, and checks that the limiter stays blocked at 999 ns and is unblocked at exactly 1000 ns. Before the fix, the timer is disarmed and `event_handler` returns `SpuriousRateLimiterEvent`. End-to-end testing on a real microVM with `size=4095` and `refill_time=1` also confirms that the second read no longer hangs.

## License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. For more information on following Developer Certificate of Origin and signing off your commits, please check
[`CONTRIBUTING.md`][3].

## PR Checklist

- [x] I have read and understand [CONTRIBUTING.md][3].
- [x] I have run `tools/devtool checkbuild --all` to verify that the PR passes
  build checks on all supported architectures.
- [x] I have run `tools/devtool checkstyle --no-clippy` to verify that the PR
  passes the automated style checks.
- [x] I have described what is done in these changes, why they are needed, and
  how they are solving the problem in a clear and encompassing way.
- [x] I have updated any relevant documentation (both in code and in the docs,
  in the PR).
- [x] I have mentioned all user-facing changes in `CHANGELOG.md`.
- [x] If a specific issue led to this PR, this PR closes the issue.
- [ ] When making API changes, I have followed the
  [Runbook for Firecracker API changes][2].
- [x] I have tested all new and changed functionalities in unit tests and/or
  integration tests.
- [ ] I have linked an issue to every new `TODO`.

______________________________________________________________________

- [ ] This functionality cannot be added in [`rust-vmm`][1].

[1]: https://github.com/rust-vmm
[2]: https://github.com/firecracker-microvm/firecracker/blob/main/docs/api-change-runbook.md
[3]: https://github.com/firecracker-microvm/firecracker/blob/main/CONTRIBUTING.md